### PR TITLE
feat: implement transpile module

### DIFF
--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -1,1 +1,39 @@
-export {};
+import { build } from 'esbuild';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function resolveRuntimePath(dir: string = __dirname): string {
+  const jsPath = resolve(dir, 'runtime.js');
+  if (existsSync(jsPath)) return jsPath;
+  const tsPath = resolve(dir, 'runtime.ts');
+  if (existsSync(tsPath)) return tsPath;
+  throw new Error(`Grafex runtime not found. Expected runtime.js or runtime.ts at: ${dir}`);
+}
+
+export async function transpile(compositionPath: string): Promise<string> {
+  const absolutePath = resolve(compositionPath);
+  const runtimePath = resolveRuntimePath();
+
+  let result;
+  try {
+    result = await build({
+      entryPoints: [absolutePath],
+      bundle: true,
+      write: false,
+      format: 'esm',
+      jsxFactory: 'h',
+      jsxFragment: 'Fragment',
+      inject: [runtimePath],
+      platform: 'node',
+      target: 'node18',
+      loader: { '.ts': 'ts', '.tsx': 'tsx' },
+    });
+  } catch (err) {
+    throw new Error(`esbuild transpilation failed:\n${(err as Error).message}`);
+  }
+
+  return result.outputFiles[0].text;
+}

--- a/test/unit/transpile.test.ts
+++ b/test/unit/transpile.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect } from 'vitest';
+import { transpile, resolveRuntimePath } from '../../src/transpile.js';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, '../fixtures');
+
+describe('transpile — basic output', () => {
+  test('transpiling simple.tsx returns a non-empty string', async () => {
+    const output = await transpile(resolve(fixturesDir, 'simple.tsx'));
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test('output contains h( calls (JSX factory injection)', async () => {
+    const output = await transpile(resolve(fixturesDir, 'simple.tsx'));
+    expect(output).toContain('h(');
+  });
+
+  test('output contains no raw JSX syntax (no angle-bracket elements)', async () => {
+    const output = await transpile(resolve(fixturesDir, 'simple.tsx'));
+    // JSX elements like <div or <h1 should not appear in transpiled output
+    expect(output).not.toMatch(/<[a-zA-Z][a-zA-Z0-9]*/);
+  });
+
+  test('output is valid ESM (contains export)', async () => {
+    const output = await transpile(resolve(fixturesDir, 'simple.tsx'));
+    expect(output).toMatch(/export/);
+  });
+});
+
+describe('transpile — fixture files', () => {
+  test('transpiling with-props.tsx returns a non-empty string without throwing', async () => {
+    const output = await transpile(resolve(fixturesDir, 'with-props.tsx'));
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test('transpiling with-components.tsx returns a non-empty string without throwing', async () => {
+    const output = await transpile(resolve(fixturesDir, 'with-components.tsx'));
+    expect(output.length).toBeGreaterThan(0);
+  });
+});
+
+describe('transpile — error propagation', () => {
+  test('throws an Error with esbuild message when composition has a syntax error', async () => {
+    const tmpFile = join(tmpdir(), `grafex-test-invalid-${Date.now()}.tsx`);
+    writeFileSync(tmpFile, 'export default function Bad() { return <div INVALID SYNTAX !!! }');
+    try {
+      await expect(transpile(tmpFile)).rejects.toThrow(Error);
+    } finally {
+      unlinkSync(tmpFile);
+    }
+  });
+
+  test('error message includes esbuild error text', async () => {
+    const tmpFile = join(tmpdir(), `grafex-test-invalid-${Date.now()}.tsx`);
+    writeFileSync(tmpFile, 'const x: = 5;');
+    try {
+      await expect(transpile(tmpFile)).rejects.toThrow(/esbuild|error|Expected|Unexpected/i);
+    } finally {
+      unlinkSync(tmpFile);
+    }
+  });
+
+  test('error message contains custom prefix "esbuild transpilation failed:"', async () => {
+    const tmpFile = join(tmpdir(), `grafex-test-invalid-${Date.now()}.tsx`);
+    writeFileSync(tmpFile, 'const x: = 5;');
+    try {
+      await expect(transpile(tmpFile)).rejects.toThrow('esbuild transpilation failed:');
+    } finally {
+      unlinkSync(tmpFile);
+    }
+  });
+});
+
+describe('transpile — resolveRuntimePath missing runtime', () => {
+  test('throws when neither runtime.js nor runtime.ts exists at the given dir', () => {
+    expect(() => resolveRuntimePath('/tmp/no-such-dir-grafex-test')).toThrow(
+      'Grafex runtime not found',
+    );
+  });
+
+  test('error message includes the expected directory path', () => {
+    const dir = '/tmp/no-such-dir-grafex-test';
+    expect(() => resolveRuntimePath(dir)).toThrow(dir);
+  });
+});
+
+describe('transpile — module exports', () => {
+  test('transpile is a named export', async () => {
+    const mod = await import('../../src/transpile.js');
+    expect(typeof mod.transpile).toBe('function');
+  });
+
+  test('named exports are transpile and resolveRuntimePath', async () => {
+    const mod = await import('../../src/transpile.js');
+    const exports = Object.keys(mod).sort();
+    expect(exports).toEqual(['resolveRuntimePath', 'transpile']);
+  });
+});


### PR DESCRIPTION
## Summary

- esbuild wrapper: TSX/JSX → ESM with custom JSX factory (`h`, `Fragment`)
- Runtime injection via `import.meta.url` path resolution
- Descriptive errors on syntax failures and missing runtime

## Test plan

- [x] 13 unit tests covering all acceptance criteria
- [x] Syntax error propagation with custom prefix
- [x] Runtime path validation (throws if missing)