### PR TITLE
test: configure vitest workspace for unit/integration separation

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     environment: 'node',
     testTimeout: 30_000,
-    include: ['test/unit/**/*.test.ts', 'test/integration/**/*.test.ts'],
   },
 });

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,21 @@
+import { defineWorkspace } from 'vitest/config';
+
+export default defineWorkspace([
+  {
+    test: {
+      name: 'unit',
+      environment: 'node',
+      include: ['test/unit/**/*.test.ts'],
+      testTimeout: 30_000,
+    },
+  },
+  {
+    test: {
+      name: 'integration',
+      environment: 'node',
+      include: ['test/integration/**/*.test.ts'],
+      pool: 'forks',
+      testTimeout: 60_000,
+    },
+  },
+]);


### PR DESCRIPTION
## Summary

- Vitest workspace with `unit` and `integration` projects
- `npx vitest run --project unit` runs 126 tests without launching a browser
- Integration tests use `pool: 'forks'` for browser process isolation

## Test plan

- [x] `npx vitest run --project unit` — 126 tests, no browser
- [x] `npx vitest run` — 153 tests, all pass
- [x] TypeScript clean, prettier clean