### PR TITLE
test: add integration tests for render pipeline and CLI

### DIFF
--- a/test/integration/cli.test.ts
+++ b/test/integration/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, afterAll } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,8 +12,14 @@ function runCli(args: string[]) {
   return spawnSync('npx', ['tsx', cliPath, ...args], {
     cwd: rootDir,
     encoding: 'utf-8',
+    timeout: 30000,
   });
 }
+
+afterAll(async () => {
+  const { close } = await import('../../src/index.js');
+  await close();
+});
 
 describe('export command — successful render', () => {
   test('exports simple.tsx to /tmp/out-cli-test.png, prints path to stdout, exits 0', () => {
@@ -43,4 +49,43 @@ describe('export command — successful render', () => {
     expect(result.status).toBe(0);
     expect(existsSync(outPath)).toBe(true);
   }, 30_000);
+});
+
+describe('export command — error cases', () => {
+  test('missing --file exits 1 with non-empty stderr', () => {
+    const result = runCli(['export', '--out', '/tmp/grafex-no-file.png']);
+    expect(result.status).toBe(1);
+    expect(result.stderr.trim().length).toBeGreaterThan(0);
+  });
+
+  test('--format svg exits 1 with unsupported format message in stderr', () => {
+    const result = runCli([
+      'export',
+      '--file',
+      'test/fixtures/simple.tsx',
+      '--format',
+      'svg',
+      '--out',
+      '/tmp/grafex-svg-test.png',
+    ]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Only PNG format is supported in this version.');
+  });
+});
+
+describe('global flags', () => {
+  test('--version exits 0 and stdout matches package.json version', () => {
+    const pkg = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf-8')) as {
+      version: string;
+    };
+    const result = runCli(['--version']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(pkg.version);
+  });
+
+  test('--help exits 0 and stdout contains "export"', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('export');
+  });
 });

--- a/test/integration/render.test.ts
+++ b/test/integration/render.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BrowserManager } from '../../src/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, '../fixtures');
+
+afterAll(async () => {
+  const { close } = await import('../../src/index.js');
+  await close();
+});
+
+// --- Shared-singleton render tests ---
+
+describe('render() — integration', () => {
+  test('render(simple.tsx) returns RenderResult with non-empty buffer', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'simple.tsx'));
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  test('result.buffer starts with PNG magic bytes 89 50 4E 47', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'simple.tsx'));
+    expect(result.buffer[0]).toBe(0x89);
+    expect(result.buffer[1]).toBe(0x50);
+    expect(result.buffer[2]).toBe(0x4e);
+    expect(result.buffer[3]).toBe(0x47);
+  });
+
+  test('result.width and result.height match the fixture config dimensions', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'simple.tsx'));
+    // simple.tsx config: width: 800, height: 400
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(400);
+  });
+
+  test('result.format is "png"', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'simple.tsx'));
+    expect(result.format).toBe('png');
+  });
+
+  test('render() with options.props passes props to the composition', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'with-props.tsx'), {
+      props: { title: 'Integration Test' },
+    });
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  test('render() with options.width and options.height overrides produce matching RenderResult', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'simple.tsx'), {
+      width: 1024,
+      height: 512,
+    });
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(512);
+  });
+
+  test('two sequential render() calls both succeed (browser reuse)', async () => {
+    const { render } = await import('../../src/index.js');
+    const result1 = await render(resolve(fixturesDir, 'simple.tsx'));
+    const result2 = await render(resolve(fixturesDir, 'simple.tsx'));
+    expect(result1.buffer.length).toBeGreaterThan(0);
+    expect(result2.buffer.length).toBeGreaterThan(0);
+  });
+
+  test('rendering with-components.tsx succeeds (sub-component resolution)', async () => {
+    const { render } = await import('../../src/index.js');
+    const result = await render(resolve(fixturesDir, 'with-components.tsx'));
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+});
+
+// --- Timing tests (isolated BrowserManager) ---
+
+describe('render() — timing', () => {
+  test('cold start timing for simple.tsx is under 3000ms', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    const manager = new BrowserManager();
+    try {
+      const start = Date.now();
+      await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(3000);
+    } finally {
+      await manager.close();
+    }
+  });
+
+  test('warm render timing for simple.tsx is under 500ms', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    const manager = new BrowserManager();
+    try {
+      // First render warms the browser
+      await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+      const start = Date.now();
+      await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(500);
+    } finally {
+      await manager.close();
+    }
+  });
+});
+
+// --- State-mutation tests (isolated BrowserManager) ---
+
+describe('render() — close and re-launch', () => {
+  test('close() after rendering does not throw', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    const manager = new BrowserManager();
+    await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+    await expect(manager.close()).resolves.not.toThrow();
+  });
+
+  test('render() after close() succeeds (re-launch)', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    const manager = new BrowserManager();
+    try {
+      await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+      await manager.close();
+      const result = await pipeline(resolve(fixturesDir, 'simple.tsx'), undefined, manager);
+      expect(Buffer.isBuffer(result.buffer)).toBe(true);
+      expect(result.buffer[0]).toBe(0x89);
+      expect(result.buffer[1]).toBe(0x50);
+      expect(result.buffer[2]).toBe(0x4e);
+      expect(result.buffer[3]).toBe(0x47);
+    } finally {
+      await manager.close();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,20 @@ export default defineConfig({
   test: {
     environment: 'node',
     testTimeout: 30_000,
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['test/unit/**/*.test.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          include: ['test/integration/**/*.test.ts'],
+          pool: 'forks',
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- 12 render pipeline integration tests (PNG bytes, dimensions, props, overrides, browser reuse, close/re-launch, timing)
- CLI subprocess tests with 30s timeout protection
- Isolated BrowserManager instances for timing and state-mutation tests

## Test plan

- [x] 169 total tests (126 unit + 43 integration)
- [x] Cold start < 3000ms, warm render < 500ms
- [x] All CLI error paths tested (missing file, invalid format, version, help)