### PR TITLE
fix: add default export entry for tsx/CJS loader compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- Added `default` entry to `exports` field in package.json
- Fixed `ERR_PACKAGE_PATH_NOT_EXPORTED` when importing via `tsx` or CJS-based loaders
- Moved `types` to first position per TypeScript recommendations

Found during post-implementation validation (Task 11).

## Test plan

- [x] `npx tsx consumer.ts` with `import { render } from 'grafex'` works
- [x] `npx tsc --noEmit` type checks clean
- [x] All 169 tests pass