### PR TITLE
fix: prevent user tsconfig from overriding JSX factory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,7 +1676,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3340,7 +3339,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -30,6 +30,13 @@ export async function transpile(compositionPath: string): Promise<string> {
       platform: 'node',
       target: 'node18',
       loader: { '.ts': 'ts', '.tsx': 'tsx' },
+      tsconfigRaw: {
+        compilerOptions: {
+          jsx: 'react',
+          jsxFactory: 'h',
+          jsxFragmentFactory: 'Fragment',
+        },
+      },
     });
   } catch (err) {
     throw new Error(`esbuild transpilation failed:\n${(err as Error).message}`);

--- a/test/unit/transpile.test.ts
+++ b/test/unit/transpile.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, afterEach } from 'vitest';
 import { transpile, resolveRuntimePath } from '../../src/transpile.js';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
@@ -100,5 +100,60 @@ describe('transpile — module exports', () => {
     const mod = await import('../../src/transpile.js');
     const exports = Object.keys(mod).sort();
     expect(exports).toEqual(['resolveRuntimePath', 'transpile']);
+  });
+});
+
+describe('transpile — CWD with node_modules', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('h() returns HtmlString (not plain object) when CWD has a tsconfig.json with jsxImportSource', async () => {
+    tmpDir = join(tmpdir(), `grafex-test-cwd-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    // Simulate a project with react in node_modules and tsconfig.json that sets jsxImportSource
+    mkdirSync(join(tmpDir, 'node_modules', 'react'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'node_modules', 'react', 'jsx-runtime.js'),
+      'export function jsx(type, props) { return { type, props }; }\nexport function jsxs(type, props) { return { type, props }; }\nexport const Fragment = Symbol("Fragment");\n',
+    );
+    writeFileSync(
+      join(tmpDir, 'node_modules', 'react', 'package.json'),
+      JSON.stringify({
+        name: 'react',
+        version: '18.0.0',
+        type: 'module',
+        exports: { '.': './index.js', './jsx-runtime': './jsx-runtime.js' },
+      }),
+    );
+    writeFileSync(
+      join(tmpDir, 'tsconfig.json'),
+      JSON.stringify({ compilerOptions: { jsx: 'react-jsx', jsxImportSource: 'react' } }),
+    );
+
+    const compositionPath = join(tmpDir, 'test.tsx');
+    writeFileSync(
+      compositionPath,
+      'export const config = { width: 800, height: 400 };\nexport default function Test() { return <div>Hello</div>; }\n',
+    );
+
+    const code = await transpile(compositionPath);
+
+    // The output must use h( not jsx( — meaning grafex's factory was used, not react's
+    expect(code).toContain('h(');
+    expect(code).not.toContain('jsx(');
+
+    // Execute the transpiled code and verify the component returns an HtmlString, not a plain object
+    const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}#${Date.now()}`;
+    const mod = await import(dataUrl);
+    const component = mod.default as () => unknown;
+    const result = component();
+
+    // If h() returned an HtmlString, String(result) gives HTML. If plain object, it gives [object Object].
+    expect(String(result)).not.toBe('[object Object]');
+    expect(String(result)).toContain('<div');
   });
 });


### PR DESCRIPTION
## Summary

- Pass `tsconfigRaw` to esbuild's `build()` call with explicit `jsx: 'react'`, `jsxFactory: 'h'`, `jsxFragmentFactory: 'Fragment'`
- This prevents esbuild from reading the user's `tsconfig.json` which may set `jsx: 'react-jsx'` and `jsxImportSource: 'react'`, causing compositions to render `[object Object]`

## Root cause

When a composition is transpiled from a directory with a `tsconfig.json` that sets `jsx: 'react-jsx'`, esbuild switches to the automatic JSX transform and emits `jsx()` calls instead of `h()`. These resolve to React's `jsx-runtime` which returns plain objects, not HTML strings.

## Test plan

- [x] New regression test: creates temp dir with React tsconfig + fake react/jsx-runtime, verifies output contains `h(` not `jsx(`
- [x] All 170 existing tests pass