### PR TITLE
feat: custom font support via config.fonts

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -131,6 +131,12 @@ export class BrowserManager {
     const page = this.page!;
     await page.setViewportSize(viewport);
     await page.setContent(html, { waitUntil: 'load' });
+    await page.evaluate(() =>
+      Promise.race([
+        document.fonts.ready,
+        new Promise<void>((resolve) => setTimeout(resolve, 5000)),
+      ]),
+    );
 
     const screenshotOptions =
       this.engine === 'chromium'

--- a/src/render.ts
+++ b/src/render.ts
@@ -27,7 +27,7 @@ export async function pipeline(
   const height = options.height ?? config.height ?? 630;
 
   const componentHtml = String(component(options.props ?? {}));
-  const html = renderToHTML(componentHtml, { width, height });
+  const html = renderToHTML(componentHtml, { width, height }, config.fonts);
 
   const buffer = await manager.render(html, { width, height });
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -58,6 +58,19 @@ function renderChildren(children: unknown): string {
   return String(children);
 }
 
+function renderRawChildren(children: unknown): string {
+  if (children === null || children === undefined || children === false || children === true) {
+    return '';
+  }
+  if (children instanceof HtmlString) return children.value;
+  if (typeof children === 'string') return children;
+  if (typeof children === 'number') return String(children);
+  if (Array.isArray(children)) return children.map(renderRawChildren).join('');
+  return String(children);
+}
+
+const RAW_TEXT_ELEMENTS = new Set(['style', 'script']);
+
 export function h(
   tag: string | ((props: Props) => HtmlString),
   props: Props | null,
@@ -65,10 +78,10 @@ export function h(
 ): HtmlString {
   const allProps = props ?? {};
   const flatChildren = children.flat(Infinity);
+  const isRaw = typeof tag === 'string' && RAW_TEXT_ELEMENTS.has(tag);
+  const renderFn = isRaw ? renderRawChildren : renderChildren;
   const childContent =
-    'children' in allProps
-      ? renderChildren(allProps.children)
-      : flatChildren.map(renderChildren).join('');
+    'children' in allProps ? renderFn(allProps.children) : flatChildren.map(renderFn).join('');
 
   if (typeof tag === 'function') {
     return tag({ ...allProps, children: childContent });
@@ -101,12 +114,19 @@ export function Fragment({ children }: { children?: unknown }): HtmlString {
 export function renderToHTML(
   componentHtml: string,
   viewport: { width: number; height: number },
+  fonts?: string[],
 ): string {
+  const fontLinks =
+    fonts && fonts.length > 0
+      ? fonts
+          .map((url) => `<link rel="stylesheet" href="${escapeHtml(url)}" crossorigin>`)
+          .join('\n') + '\n'
+      : '';
   return `<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
-<style>
+${fontLinks}<style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { width: ${viewport.width}px; height: ${viewport.height}px; overflow: hidden; }
 </style>

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,4 +17,5 @@ export interface CompositionConfig {
   width?: number;
   height?: number;
   format?: 'png';
+  fonts?: string[];
 }

--- a/test/fixtures/with-fonts.tsx
+++ b/test/fixtures/with-fonts.tsx
@@ -1,0 +1,24 @@
+import type { CompositionConfig } from '../../src/types.js';
+
+export const config: CompositionConfig = {
+  width: 800,
+  height: 400,
+  fonts: ['https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap'],
+};
+
+export default function WithFonts() {
+  return (
+    <div
+      style={{
+        width: '800px',
+        height: '400px',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <h1>Custom Font Composition</h1>
+    </div>
+  );
+}

--- a/test/integration/fonts.test.ts
+++ b/test/integration/fonts.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { pipeline } from '../../src/render.js';
+import { BrowserManager } from '../../src/browser.js';
+import { renderToHTML } from '../../src/runtime.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, '../fixtures');
+
+const manager = new BrowserManager({ idleTimeoutMs: 5000 });
+
+afterAll(async () => {
+  await manager.close();
+});
+
+describe('custom fonts — integration', () => {
+  test('with-fonts.tsx renders without error', async () => {
+    const result = await pipeline(resolve(fixturesDir, 'with-fonts.tsx'), {}, manager);
+    expect(result.format).toBe('png');
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  test('with-fonts.tsx produces HTML with Google Fonts link tag', async () => {
+    const fonts = ['https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap'];
+    const html = renderToHTML('<div>hello</div>', { width: 800, height: 400 }, fonts);
+    expect(html).toContain(
+      '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&amp;display=swap" crossorigin>',
+    );
+    expect(html).toContain('</head>');
+    const headClose = html.indexOf('</head>');
+    const linkPos = html.indexOf('<link rel="stylesheet"');
+    expect(linkPos).toBeLessThan(headClose);
+  });
+});

--- a/test/unit/render.test.ts
+++ b/test/unit/render.test.ts
@@ -207,6 +207,29 @@ describe('pipeline() — import cache (nonce)', () => {
   });
 });
 
+describe('pipeline() — fonts passthrough', () => {
+  let mockManager: ReturnType<typeof makeMockManager>;
+
+  beforeEach(() => {
+    mockManager = makeMockManager();
+  });
+
+  test('config.fonts are present in the HTML passed to the browser', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    await pipeline(resolve(fixturesDir, 'with-fonts.tsx'), {}, mockManager as any);
+    const [html] = mockManager.render.mock.calls[0] as [string, unknown];
+    expect(html).toContain('<link rel="stylesheet"');
+    expect(html).toContain('fonts.googleapis.com');
+  });
+
+  test('composition without fonts config produces no link tags', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    await pipeline(resolve(fixturesDir, 'simple.tsx'), {}, mockManager as any);
+    const [html] = mockManager.render.mock.calls[0] as [string, unknown];
+    expect(html).not.toContain('<link rel="stylesheet"');
+  });
+});
+
 describe('pipeline() — with-components fixture', () => {
   let mockManager: ReturnType<typeof makeMockManager>;
 

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -302,6 +302,65 @@ describe('HtmlString', () => {
   });
 });
 
+describe('h() — style and script raw content (no escaping)', () => {
+  test('style child is NOT escaped', () => {
+    expect(String(h('style', null, 'body { color: red }'))).toBe(
+      '<style>body { color: red }</style>',
+    );
+  });
+
+  test('style child with angle brackets is NOT escaped', () => {
+    expect(String(h('style', null, '<script>alert("xss")</script>'))).toBe(
+      '<style><script>alert("xss")</script></style>',
+    );
+  });
+
+  test('script child is NOT escaped', () => {
+    expect(String(h('script', null, 'if (a < b) { console.log("ok") }'))).toBe(
+      '<script>if (a < b) { console.log("ok") }</script>',
+    );
+  });
+
+  test('div child IS still escaped', () => {
+    expect(String(h('div', null, '<b>bold</b>'))).toBe('<div>&lt;b&gt;bold&lt;/b&gt;</div>');
+  });
+});
+
+describe('renderToHTML — fonts', () => {
+  test('injects link tags for each font URL in head', () => {
+    const fonts = [
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap',
+      'https://fonts.googleapis.com/css2?family=Roboto&display=swap',
+    ];
+    const html = renderToHTML('<p>hi</p>', { width: 1200, height: 630 }, fonts);
+    expect(html).toContain(
+      '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&amp;display=swap" crossorigin>',
+    );
+    expect(html).toContain(
+      '<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto&amp;display=swap" crossorigin>',
+    );
+  });
+
+  test('link tags appear inside head', () => {
+    const fonts = ['https://fonts.googleapis.com/css2?family=Inter&display=swap'];
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, fonts);
+    const headClose = html.indexOf('</head>');
+    const linkPos = html.indexOf('<link rel="stylesheet"');
+    expect(linkPos).toBeGreaterThan(-1);
+    expect(linkPos).toBeLessThan(headClose);
+  });
+
+  test('empty fonts array produces no link tags', () => {
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, []);
+    expect(html).not.toContain('<link rel="stylesheet"');
+  });
+
+  test('undefined fonts produces no link tags', () => {
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 });
+    expect(html).not.toContain('<link rel="stylesheet"');
+  });
+});
+
 describe('module exports', () => {
   test('h is exported', () => {
     expect(typeof h).toBe('function');


### PR DESCRIPTION
## Summary

- `config.fonts` array: URLs injected as `<link rel="stylesheet">` in HTML `<head>`
- `document.fonts.ready` wait with 5s timeout before screenshot
- `<style>` and `<script>` elements no longer HTML-escape children (raw text)
- Font URLs are HTML-escaped in href attributes (XSS protection)

## Usage

```tsx
export const config = {
  width: 1200,
  height: 630,
  fonts: ['https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700'],
};

export default function Card() {
  return <h1 style={{ fontFamily: "'Playfair Display', serif" }}>Hello</h1>;
}
```

## Test plan

- [x] 182 tests pass (10 new: unit + integration)
- [x] Font URLs escaped in href attributes
- [x] `<style>` children not escaped
- [x] Verified visually: Playfair Display + Bungee Shade render correctly