### PR TITLE
feat: CSS file injection via config.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,51 @@ import { h, Fragment, renderToHTML, BrowserManager } from 'grafex';
 
 ---
 
+## CSS Files
+
+Load external CSS files by specifying paths in `config.css`. Paths are resolved relative to the composition file:
+
+```tsx
+export const config: CompositionConfig = {
+  width: 1200,
+  height: 630,
+  css: ['./styles.css'],
+};
+```
+
+This works with any CSS — plain stylesheets, Tailwind output, Sass output, anything that produces a `.css` file. The contents are injected as `<style>` tags in the HTML `<head>` before rendering.
+
+**Tailwind CSS example:**
+
+```bash
+# 1. Generate the CSS
+npx tailwindcss -i ./input.css -o ./styles.css
+```
+
+```tsx
+// card.tsx
+export const config: CompositionConfig = {
+  width: 1200,
+  height: 630,
+  css: ['./styles.css'],
+};
+
+export default function Card() {
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
+      <h1 className="text-6xl font-bold">Hello Tailwind</h1>
+    </div>
+  );
+}
+```
+
+```bash
+# 2. Export the composition
+npx grafex export -f card.tsx -o card.png
+```
+
+---
+
 ## Browser Installation
 
 WebKit is downloaded automatically when you run `npm install` via the `postinstall` script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "esbuild": "^0.24.0",

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,5 @@
-import { resolve } from 'node:path';
+import { resolve, dirname } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import { transpile } from './transpile.js';
 import { renderToHTML } from './runtime.js';
 import { BrowserManager } from './browser.js';
@@ -29,8 +30,21 @@ export async function pipeline(
   const format = options.format ?? config.format ?? 'png';
   const quality = options.quality ?? config.quality ?? (format === 'jpeg' ? 90 : undefined);
 
+  const compositionDir = dirname(absolutePath);
+  const cssContents: string[] = [];
+  if (config.css && config.css.length > 0) {
+    for (const cssPath of config.css) {
+      const resolvedCssPath = resolve(compositionDir, cssPath);
+      try {
+        cssContents.push(await readFile(resolvedCssPath, 'utf-8'));
+      } catch {
+        throw new Error(`CSS file not found: "${resolvedCssPath}" (referenced in ${absolutePath})`);
+      }
+    }
+  }
+
   const componentHtml = String(component(options.props ?? {}));
-  const html = renderToHTML(componentHtml, { width, height }, config.fonts);
+  const html = renderToHTML(componentHtml, { width, height }, config.fonts, cssContents);
 
   const buffer = await manager.render(html, { width, height }, scale, format, quality);
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -115,11 +115,18 @@ export function renderToHTML(
   componentHtml: string,
   viewport: { width: number; height: number },
   fonts?: string[],
+  css?: string[],
 ): string {
   const fontLinks =
     fonts && fonts.length > 0
       ? fonts
           .map((url) => `<link rel="stylesheet" href="${escapeHtml(url)}" crossorigin>`)
+          .join('\n') + '\n'
+      : '';
+  const cssStyles =
+    css && css.length > 0
+      ? css
+          .map((content) => `<style>${content.replace(/<\/style>/gi, '<\\/style>')}</style>`)
           .join('\n') + '\n'
       : '';
   return `<!DOCTYPE html>
@@ -130,7 +137,7 @@ ${fontLinks}<style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { width: ${viewport.width}px; height: ${viewport.height}px; overflow: hidden; }
 </style>
-</head>
+${cssStyles}</head>
 <body>
 ${componentHtml}
 </body>

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,4 +23,5 @@ export interface CompositionConfig {
   format?: 'png' | 'jpeg';
   quality?: number;
   fonts?: string[];
+  css?: string[];
 }

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,4 @@
+.grafex-test {
+  color: white;
+  font-size: 48px;
+}

--- a/test/fixtures/with-css.tsx
+++ b/test/fixtures/with-css.tsx
@@ -1,0 +1,25 @@
+import type { CompositionConfig } from '../../src/types.js';
+
+export const config: CompositionConfig = {
+  width: 800,
+  height: 400,
+  css: ['./styles.css'],
+};
+
+export default function WithCss() {
+  return (
+    <div
+      className="grafex-test"
+      style={{
+        width: '800px',
+        height: '400px',
+        background: '#0f172a',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      CSS Support
+    </div>
+  );
+}

--- a/test/fixtures/with-missing-css.tsx
+++ b/test/fixtures/with-missing-css.tsx
@@ -1,0 +1,11 @@
+import type { CompositionConfig } from '../../src/types.js';
+
+export const config: CompositionConfig = {
+  width: 800,
+  height: 400,
+  css: ['./nonexistent.css'],
+};
+
+export default function WithMissingCss() {
+  return <div style={{ width: '800px', height: '400px' }}>Missing CSS</div>;
+}

--- a/test/integration/css.test.ts
+++ b/test/integration/css.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, afterAll } from 'vitest';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { pipeline } from '../../src/render.js';
+import { BrowserManager } from '../../src/browser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, '../fixtures');
+
+const manager = new BrowserManager({ idleTimeoutMs: 5000 });
+
+afterAll(async () => {
+  await manager.close();
+});
+
+describe('css files — integration', () => {
+  test('with-css.tsx renders without error', async () => {
+    const result = await pipeline(resolve(fixturesDir, 'with-css.tsx'), {}, manager);
+    expect(result.format).toBe('png');
+    expect(Buffer.isBuffer(result.buffer)).toBe(true);
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  test('with-css.tsx produces HTML with injected style tag containing CSS content', async () => {
+    const { renderToHTML } = await import('../../src/runtime.js');
+    const html = renderToHTML(
+      '<div class="grafex-test">test</div>',
+      { width: 800, height: 400 },
+      undefined,
+      ['.grafex-test { color: white; font-size: 48px; }\n'],
+    );
+    expect(html).toContain('<style>.grafex-test');
+    expect(html).toContain('</head>');
+    const headClose = html.indexOf('</head>');
+    const stylePos = html.lastIndexOf('<style>.grafex-test');
+    expect(stylePos).toBeLessThan(headClose);
+  });
+});

--- a/test/unit/render.test.ts
+++ b/test/unit/render.test.ts
@@ -317,6 +317,37 @@ describe('pipeline() — scale', () => {
   });
 });
 
+describe('pipeline() — css passthrough', () => {
+  let mockManager: ReturnType<typeof makeMockManager>;
+
+  beforeEach(() => {
+    mockManager = makeMockManager();
+  });
+
+  test('config.css contents are present as style tags in the HTML passed to the browser', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    await pipeline(resolve(fixturesDir, 'with-css.tsx'), {}, mockManager as any);
+    const [html] = mockManager.render.mock.calls[0] as [string, unknown];
+    expect(html).toContain('<style>');
+    expect(html).toContain('.grafex-test');
+  });
+
+  test('missing css file throws descriptive error with path', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    await expect(
+      pipeline(resolve(fixturesDir, 'with-missing-css.tsx'), {}, mockManager as any),
+    ).rejects.toThrow('with-missing-css.tsx');
+  });
+
+  test('composition without css config produces only reset style tag', async () => {
+    const { pipeline } = await import('../../src/render.js');
+    await pipeline(resolve(fixturesDir, 'simple.tsx'), {}, mockManager as any);
+    const [html] = mockManager.render.mock.calls[0] as [string, unknown];
+    const styleCount = (html.match(/<style>/g) ?? []).length;
+    expect(styleCount).toBe(1);
+  });
+});
+
 describe('pipeline() — with-components fixture', () => {
   let mockManager: ReturnType<typeof makeMockManager>;
 

--- a/test/unit/runtime.test.ts
+++ b/test/unit/runtime.test.ts
@@ -326,6 +326,53 @@ describe('h() — style and script raw content (no escaping)', () => {
   });
 });
 
+describe('renderToHTML — css', () => {
+  test('injects style tags for each CSS string in head', () => {
+    const css = ['body { color: red; }', '.title { font-size: 64px; }'];
+    const html = renderToHTML('<p>hi</p>', { width: 1200, height: 630 }, undefined, css);
+    expect(html).toContain('<style>body { color: red; }</style>');
+    expect(html).toContain('<style>.title { font-size: 64px; }</style>');
+  });
+
+  test('style tags appear inside head', () => {
+    const css = ['.foo { color: blue; }'];
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, undefined, css);
+    const headClose = html.indexOf('</head>');
+    const stylePos = html.lastIndexOf('<style>');
+    expect(stylePos).toBeGreaterThan(-1);
+    expect(stylePos).toBeLessThan(headClose);
+  });
+
+  test('css style tags appear after font link tags', () => {
+    const fonts = ['https://fonts.googleapis.com/css2?family=Inter&display=swap'];
+    const css = ['.foo { color: blue; }'];
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, fonts, css);
+    const linkPos = html.indexOf('<link rel="stylesheet"');
+    const cssStylePos = html.indexOf('<style>.foo');
+    expect(linkPos).toBeGreaterThan(-1);
+    expect(cssStylePos).toBeGreaterThan(linkPos);
+  });
+
+  test('</style> in css content is escaped to prevent early tag termination', () => {
+    const css = ['/* </style> trick */ body { color: red; }'];
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, undefined, css);
+    expect(html).not.toContain('</style> trick');
+    expect(html).toContain('<\\/style>');
+  });
+
+  test('empty css array produces no extra style tags beyond reset', () => {
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 }, undefined, []);
+    const styleCount = (html.match(/<style>/g) ?? []).length;
+    expect(styleCount).toBe(1);
+  });
+
+  test('undefined css produces no extra style tags beyond reset', () => {
+    const html = renderToHTML('<p>hi</p>', { width: 800, height: 600 });
+    const styleCount = (html.match(/<style>/g) ?? []).length;
+    expect(styleCount).toBe(1);
+  });
+});
+
 describe('renderToHTML — fonts', () => {
   test('injects link tags for each font URL in head', () => {
     const fonts = [

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -4,7 +4,7 @@
 
 Grafex works as both a CLI tool (`npx grafex export`) and a Node.js library (`import { render } from 'grafex'`). Compositions are plain TSX files that export a function component and a config object. The tool transpiles JSX via esbuild, renders HTML in a headless WebKit browser via Playwright, and screenshots the result to PNG.
 
-Key features: full CSS support (flexbox, grid, gradients, shadows, transforms), custom fonts via config.fonts (Google Fonts or any CSS URL), AI-friendly (compositions are easy for LLMs to write), sub-100ms warm renders, 2 runtime dependencies (playwright-core + esbuild).
+Key features: full CSS support (flexbox, grid, gradients, shadows, transforms), custom fonts via config.fonts (Google Fonts or any CSS URL), external CSS files via config.css (plain CSS, Tailwind output, Sass output, any .css file), AI-friendly (compositions are easy for LLMs to write), sub-100ms warm renders, 2 runtime dependencies (playwright-core + esbuild).
 
 ---
 
@@ -58,7 +58,7 @@ export default function Card() {
 
 A composition has two parts:
 1. Default export — a function that returns JSX. This is your image layout.
-2. Named `config` export — a `CompositionConfig` object that sets the output dimensions and optionally loads custom fonts.
+2. Named `config` export — a `CompositionConfig` object that sets the output dimensions and optionally loads custom fonts and CSS files.
 
 ### Export
 
@@ -76,12 +76,21 @@ Compositions are TSX files that describe your image layout. They use a custom JS
 
 ```ts
 interface CompositionConfig {
+<<<<<<< Updated upstream
   width?: number;          // Image width in pixels (default: 1200)
   height?: number;         // Image height in pixels (default: 630)
   format?: 'png' | 'jpeg'; // Output format (default: 'png')
   quality?: number;        // JPEG quality 1-100 (default: 90)
   fonts?: string[];        // URLs to font stylesheets (e.g., Google Fonts)
   scale?: number;          // Device pixel ratio (default: 1)
+=======
+  width?: number;   // Image width in pixels (default: 1200)
+  height?: number;  // Image height in pixels (default: 630)
+  format?: 'png';   // Output format (only PNG supported)
+  fonts?: string[]; // URLs to font stylesheets (e.g., Google Fonts)
+  css?: string[];   // Paths to CSS files (relative to the composition file)
+  scale?: number;   // Device pixel ratio (default: 1)
+>>>>>>> Stashed changes
 }
 ```
 
@@ -106,6 +115,28 @@ export default function Card() {
   );
 }
 ```
+
+### CSS Files
+
+Load external CSS files via `config.css`. Paths are resolved relative to the composition file. Works with plain CSS, Tailwind output, Sass output, or any `.css` file.
+
+```tsx
+export const config: CompositionConfig = {
+  width: 1200,
+  height: 630,
+  css: ['./styles.css'],
+};
+
+export default function Card() {
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
+      <h1 className="text-6xl font-bold">Hello Tailwind</h1>
+    </div>
+  );
+}
+```
+
+Tailwind recipe: run `npx tailwindcss -i ./input.css -o ./styles.css` first, then reference the output in `config.css`.
 
 ### Styling
 
@@ -257,7 +288,11 @@ interface CompositionConfig {
   format?: 'png' | 'jpeg';
   quality?: number;
   fonts?: string[];
+<<<<<<< Updated upstream
   scale?: number;
+=======
+  css?: string[];
+>>>>>>> Stashed changes
 }
 ```
 

--- a/website/src/pages/docs/api.astro
+++ b/website/src/pages/docs/api.astro
@@ -244,7 +244,7 @@ const closeCallCode = `await close();`;
           <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
             <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
               <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-              <CopyButton text={`interface CompositionConfig {\n  width?: number;          // Image width in pixels (default: 1200)\n  height?: number;         // Image height in pixels (default: 630)\n  format?: 'png' | 'jpeg'; // Output format (default: 'png')\n  quality?: number;        // JPEG quality 1-100 (default: 90)\n  fonts?: string[];        // URLs to font stylesheets (e.g., Google Fonts)\n  css?: string[];           // CSS file paths to inject\n  scale?: number;          // Device pixel ratio (default: 1)\n}`} client:load />
+              <CopyButton text={compositionConfigTypeCode} client:load />
             </div>
             <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
               <Code code={compositionConfigTypeCode} lang="typescript" theme={grafexTheme} />

--- a/website/src/pages/docs/compositions.astro
+++ b/website/src/pages/docs/compositions.astro
@@ -18,12 +18,13 @@ export default function MyImage() {
 }`;
 
 const compositionConfigCode = `interface CompositionConfig {
-  width?: number;          // Image width in pixels (default: 1200)
-  height?: number;         // Image height in pixels (default: 630)
-  format?: 'png' | 'jpeg'; // Output format (default: 'png')
-  quality?: number;        // JPEG quality 1-100 (default: 90)
-  fonts?: string[];        // URLs to font stylesheets (e.g., Google Fonts)
-  scale?: number;          // Device pixel ratio (default: 1)
+  width?: number;           // Image width in pixels (default: 1200)
+  height?: number;          // Image height in pixels (default: 630)
+  format?: 'png' | 'jpeg';  // Output format (default: 'png')
+  quality?: number;         // JPEG quality 1-100 (default: 90)
+  fonts?: string[];         // URLs to font stylesheets
+  css?: string[];           // CSS file paths to inject
+  scale?: number;           // Device pixel ratio (default: 1)
 }`;
 
 const customFontsCode = `import type { CompositionConfig } from 'grafex';
@@ -300,6 +301,79 @@ export default function OgImage() {
           <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
           Any CSS font URL works — Google Fonts, Adobe Fonts, or a self-hosted stylesheet. Grafex injects each URL as a <code class="font-mono">&lt;link&gt;</code> element before rendering.
         </p>
+      </div>
+    </section>
+
+    <!-- CSS Files -->
+    <section class="mb-12">
+      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">CSS Files</h2>
+      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Load external CSS files by specifying paths in <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code>. Paths are resolved relative to the composition file. The CSS is injected as <code class="font-mono">&lt;style&gt;</code> tags in the HTML <code class="font-mono">&lt;head&gt;</code> before rendering.</p>
+
+      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
+        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
+          <CopyButton text={`import type { CompositionConfig } from 'grafex';\n\nexport const config: CompositionConfig = {\n  width: 1200,\n  height: 630,\n  css: ['./styles.css'],\n};\n\nexport default function Card() {\n  return (\n    <div className="card">\n      <h1 className="title">Hello</h1>\n    </div>\n  );\n}`} client:load />
+        </div>
+        <div class="p-4 overflow-x-auto" style="background: var(--color-bg-code); max-height: 500px; overflow-y: auto;">
+          <pre class="font-mono text-sm leading-relaxed"><code><span style="color:#F472B6">import</span><span style="color:#94A3B8"> type {"{"} </span><span style="color:#38BDF8">CompositionConfig</span><span style="color:#94A3B8"> {"}"} </span><span style="color:#F472B6">from</span><span style="color:#A3E635"> 'grafex'</span><span style="color:#94A3B8">;</span>
+
+<span style="color:#F472B6">export</span><span style="color:#F472B6"> const</span><span style="color:#38BDF8"> config</span><span style="color:#94A3B8">:</span><span style="color:#38BDF8"> CompositionConfig</span><span style="color:#94A3B8"> = {"{"}</span>
+<span style="color:#38BDF8">  width</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 1200</span><span style="color:#94A3B8">,</span>
+<span style="color:#38BDF8">  height</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 630</span><span style="color:#94A3B8">,</span>
+<span style="color:#38BDF8">  css</span><span style="color:#94A3B8">: [</span><span style="color:#A3E635">'./styles.css'</span><span style="color:#94A3B8">],</span>
+<span style="color:#94A3B8">{"}"};</span>
+
+<span style="color:#F472B6">export</span><span style="color:#F472B6"> default</span><span style="color:#F472B6"> function</span><span style="color:#38BDF8"> Card</span><span style="color:#94A3B8">() {"{"}</span>
+<span style="color:#F472B6">  return</span><span style="color:#94A3B8"> (</span>
+<span style="color:#F472B6">    &lt;div</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"card"</span><span style="color:#F472B6">&gt;</span>
+<span style="color:#F472B6">      &lt;h1</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"title"</span><span style="color:#F472B6">&gt;</span>Hello<span style="color:#F472B6">&lt;/h1&gt;</span>
+<span style="color:#F472B6">    &lt;/div&gt;</span>
+<span style="color:#94A3B8">  );</span>
+<span style="color:#94A3B8">{"}"}</span></code></pre>
+        </div>
+      </div>
+
+      <div class="rounded-xl p-4 border-l-4 mb-6" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
+        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
+          <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
+          This is a generic file injection mechanism — it works with plain CSS, Tailwind output, Sass output, or any other `.css` file. Grafex doesn't care how the CSS was generated.
+        </p>
+      </div>
+
+      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">Tailwind CSS recipe</h3>
+      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Run Tailwind's CLI to compile your stylesheet, then reference the output in <code class="font-mono text-sm" style="color: var(--color-primary);">config.css</code>.</p>
+
+      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
+        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+          <span class="text-xs font-mono" style="color: var(--color-text-muted);">terminal</span>
+        </div>
+        <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
+          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx tailwindcss -i ./input.css -o ./styles.css</code>
+        </div>
+      </div>
+
+      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
+        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
+          <CopyButton text={`import type { CompositionConfig } from 'grafex';\n\nexport const config: CompositionConfig = {\n  width: 1200,\n  height: 630,\n  css: ['./styles.css'],\n};\n\nexport default function Card() {\n  return (\n    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white">\n      <h1 className="text-6xl font-bold">Hello Tailwind</h1>\n    </div>\n  );\n}`} client:load />
+        </div>
+        <div class="p-4 overflow-x-auto" style="background: var(--color-bg-code); max-height: 500px; overflow-y: auto;">
+          <pre class="font-mono text-sm leading-relaxed"><code><span style="color:#F472B6">import</span><span style="color:#94A3B8"> type {"{"} </span><span style="color:#38BDF8">CompositionConfig</span><span style="color:#94A3B8"> {"}"} </span><span style="color:#F472B6">from</span><span style="color:#A3E635"> 'grafex'</span><span style="color:#94A3B8">;</span>
+
+<span style="color:#F472B6">export</span><span style="color:#F472B6"> const</span><span style="color:#38BDF8"> config</span><span style="color:#94A3B8">:</span><span style="color:#38BDF8"> CompositionConfig</span><span style="color:#94A3B8"> = {"{"}</span>
+<span style="color:#38BDF8">  width</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 1200</span><span style="color:#94A3B8">,</span>
+<span style="color:#38BDF8">  height</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 630</span><span style="color:#94A3B8">,</span>
+<span style="color:#38BDF8">  css</span><span style="color:#94A3B8">: [</span><span style="color:#A3E635">'./styles.css'</span><span style="color:#94A3B8">],</span>
+<span style="color:#94A3B8">{"}"};</span>
+
+<span style="color:#F472B6">export</span><span style="color:#F472B6"> default</span><span style="color:#F472B6"> function</span><span style="color:#38BDF8"> Card</span><span style="color:#94A3B8">() {"{"}</span>
+<span style="color:#F472B6">  return</span><span style="color:#94A3B8"> (</span>
+<span style="color:#F472B6">    &lt;div</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white"</span><span style="color:#F472B6">&gt;</span>
+<span style="color:#F472B6">      &lt;h1</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"text-6xl font-bold"</span><span style="color:#F472B6">&gt;</span>Hello Tailwind<span style="color:#F472B6">&lt;/h1&gt;</span>
+<span style="color:#F472B6">    &lt;/div&gt;</span>
+<span style="color:#94A3B8">  );</span>
+<span style="color:#94A3B8">{"}"}</span></code></pre>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary

- `config.css: ['./styles.css']` — load external CSS files into compositions
- Paths resolved relative to the composition file (not CWD)
- CSS injected as `<style>` tags in HTML `<head>` after base reset and fonts
- `</style>` token escaping to prevent early tag termination
- Zero new dependencies — Tailwind is a documentation recipe, not a code dependency
- Descriptive error for missing CSS files

Closes #22

## Usage

```tsx
export const config: CompositionConfig = {
  width: 1200,
  height: 630,
  css: ['./styles.css'],
};

export default function Card() {
  return <div className="card"><h1 className="title">Hello</h1></div>;
}
```

## Test plan

- [x] 228 tests pass (12 new: unit + integration)
- [x] CSS classes applied correctly in rendered output
- [x] Missing CSS file throws descriptive error
- [x] `</style>` escape protection
- [x] CLI and library API verified visually