### PR TITLE
feat: grafex dev — watch mode with live preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ grafex export -f card.tsx -o card.png --width 800 --height 400
 
 ```
 
+### `grafex dev`
+
+Start a live preview server that watches your composition and re-renders on every file change.
+
+```bash
+npx grafex dev -f card.tsx
+```
+
+| Flag        | Short | Type          | Default | Description                                                 |
+| ----------- | ----- | ------------- | ------- | ----------------------------------------------------------- |
+| `--file`    | `-f`  | string        | —       | Path to the `.tsx` composition file **(required)**          |
+| `--port`    |       | number        | `3000`  | Preview server port                                         |
+| `--props`   |       | string (JSON) | `{}`    | Props to pass to the composition as a JSON object           |
+| `--variant` |       | string        | (first) | Show only the named variant (when composition has variants) |
+| `--help`    | `-h`  |               |         | Show help text                                              |
+
+The dev server watches the composition file, all its imports, CSS files from `config.css`, and local image assets. Changes are debounced and the preview updates within ~100ms. Open `http://localhost:3000` to see the live preview.
+
+Press `Ctrl+C` to stop.
+
 ### Global flags
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { runExport } from './commands/export.js';
+import { runDev } from './commands/dev.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json') as { version: string };
@@ -10,6 +11,7 @@ Usage: grafex <command> [options]
 
 Commands:
   export    Render a composition to a PNG file
+  dev       Watch a composition and serve a live preview
 
 Global options:
   --version, -v    Print version and exit
@@ -32,6 +34,11 @@ if (command === '--help' || command === '-h' || !command) {
 
 if (command === 'export') {
   runExport(rest).catch((err: unknown) => {
+    process.stderr.write(`Error: ${(err as Error).message}\n`);
+    process.exit(1);
+  });
+} else if (command === 'dev') {
+  runDev(rest).catch((err: unknown) => {
     process.stderr.write(`Error: ${(err as Error).message}\n`);
     process.exit(1);
   });

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -1,0 +1,666 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { watch, type FSWatcher } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { transpile } from '../transpile.js';
+import { renderToHTML } from '../runtime.js';
+import { BrowserManager } from '../browser.js';
+import { embedLocalAssets, embedCssAssets } from '../assets.js';
+import type { CompositionConfig } from '../types.js';
+import { logBanner, logRender, logChange, logError } from '../logger.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+let version = '0.0.0';
+try {
+  version = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8')).version;
+} catch {
+  try {
+    version = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')).version;
+  } catch {
+    // fallback to 0.0.0
+  }
+}
+const pkg = { version };
+
+const HELP = `
+Usage: grafex dev --file <path> [options]
+
+Options:
+  --file, -f    Path to the composition .tsx file (required)
+  --port        Preview server port (default: 3000)
+  --props       Props to pass as JSON (default: {})
+  --variant     Show only the named variant (default: first variant)
+  --help, -h    Show this help text
+`.trim();
+
+interface DevState {
+  buffers: Map<string, Buffer>;
+  sseClients: ServerResponse[];
+  currentVariant: string | null;
+  variants: string[];
+  renderTime: number;
+  compositionWidth: number;
+  compositionHeight: number;
+  compositionScale: number;
+}
+
+function openBrowser(url: string): void {
+  const bin =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+  spawn(bin, [url], { stdio: 'ignore', detached: true });
+}
+
+function buildWatchList(absolutePath: string, inputs: string[], cssPaths: string[]): Set<string> {
+  const files = new Set<string>();
+  files.add(absolutePath);
+  for (const p of inputs) {
+    files.add(p);
+  }
+  for (const p of cssPaths) {
+    files.add(p);
+  }
+  return files;
+}
+
+function previewHtml(filename: string, state: DevState, pinnedVariant: string | undefined): string {
+  const { compositionWidth, compositionHeight, compositionScale, variants, currentVariant } = state;
+  const showSwitcher = variants.length > 1;
+
+  const variantSwitcherHtml = showSwitcher
+    ? `
+    <div id="variant-bar" style="margin-bottom:12px;display:flex;align-items:center;gap:10px;">
+      <label style="font-size:13px;color:#8b949e;">Variant:</label>
+      <select id="variant-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:4px 8px;font-size:13px;cursor:pointer;">
+        ${variants.map((v) => `<option value="${v}"${v === currentVariant ? ' selected' : ''}>${v}</option>`).join('')}
+      </select>
+    </div>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>grafex dev — ${filename}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    body {
+      background: #0B0E14;
+      color: #e6edf3;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 24px;
+    }
+    #container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      max-width: 100%;
+    }
+    #img-wrapper {
+      position: relative;
+      background-color: #fff;
+      background-image:
+        linear-gradient(45deg, #ccc 25%, transparent 25%),
+        linear-gradient(-45deg, #ccc 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, #ccc 75%),
+        linear-gradient(-45deg, transparent 75%, #ccc 75%);
+      background-size: 16px 16px;
+      background-position: 0 0, 0 8px, 8px -8px, -8px 0px;
+      overflow: hidden;
+      box-shadow: 0 0 0 1px #30363d;
+    }
+    #preview-img {
+      display: none;
+      max-width: min(${compositionWidth}px, calc(100vw - 48px));
+      height: auto;
+    }
+    #preview-img.loaded {
+      display: block;
+    }
+    #loading {
+      width: min(${compositionWidth}px, calc(100vw - 48px));
+      aspect-ratio: ${compositionWidth} / ${compositionHeight};
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #484f58;
+      font-size: 14px;
+    }
+    #error-overlay {
+      display: none;
+      position: absolute;
+      inset: 0;
+      background: rgba(11,14,20,0.92);
+      overflow: auto;
+      padding: 20px;
+    }
+    #error-overlay pre {
+      color: #f85149;
+      font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+      font-size: 12px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    #info-bar {
+      font-size: 12px;
+      color: #8b949e;
+      display: flex;
+      gap: 16px;
+      align-items: center;
+    }
+    #info-bar span { display: flex; align-items: center; gap: 4px; }
+    #render-time { color: #3fb950; }
+  </style>
+</head>
+<body>
+  <div id="container">
+    ${variantSwitcherHtml}
+    <div id="img-wrapper">
+      <div id="loading">Rendering...</div>
+      <img id="preview-img" alt="Composition preview" />
+      <div id="error-overlay"><pre id="error-text"></pre></div>
+    </div>
+    <div id="info-bar">
+      <span>${filename}</span>
+      <span id="dimensions">${compositionWidth} &times; ${compositionHeight} @ ${compositionScale}x</span>
+      <span id="render-time">${state.renderTime}ms</span>
+    </div>
+  </div>
+
+  <script>
+    const img = document.getElementById('preview-img');
+    const loading = document.getElementById('loading');
+    const errorOverlay = document.getElementById('error-overlay');
+    const errorText = document.getElementById('error-text');
+    const renderTimeEl = document.getElementById('render-time');
+    const dimensionsEl = document.getElementById('dimensions');
+    ${showSwitcher ? `const variantSelect = document.getElementById('variant-select');` : ''}
+
+    function connectSSE() {
+      const url = '/events' + (window.location.search || '');
+      const es = new EventSource(url);
+
+      es.addEventListener('open', () => {
+        // On connect, try loading the current image (render may have finished before SSE connected)
+        const testImg = new Image();
+        testImg.onload = () => {
+          loading.style.display = 'none';
+          img.src = testImg.src;
+          img.classList.add('loaded');
+        };
+        testImg.src = '/image?t=' + Date.now();
+      });
+
+      es.addEventListener('render', (e) => {
+        const data = JSON.parse(e.data);
+        loading.style.display = 'none';
+        img.classList.add('loaded');
+        errorOverlay.style.display = 'none';
+        img.src = '/image?t=' + data.timestamp + (data.variant ? '&variant=' + encodeURIComponent(data.variant) : '');
+        renderTimeEl.textContent = data.renderTime + 'ms';
+        renderTimeEl.style.color = data.renderTime < 200 ? '#3fb950' : data.renderTime <= 1000 ? '#d29922' : '#f85149';
+        if (data.width != null) {
+          dimensionsEl.textContent = data.width + ' \u00d7 ' + data.height + ' @ ' + (data.scale || 1) + 'x';
+        }
+      });
+
+      es.addEventListener('reload', () => {
+        window.location.reload();
+      });
+
+      es.addEventListener('error_event', (e) => {
+        const data = JSON.parse(e.data);
+        errorText.textContent = data.message;
+        errorOverlay.style.display = 'block';
+      });
+
+      es.onerror = () => {
+        es.close();
+        setTimeout(connectSSE, 3000);
+      };
+    }
+
+    connectSSE();
+
+    ${
+      showSwitcher
+        ? `
+    variantSelect.addEventListener('change', () => {
+      const name = variantSelect.value;
+      history.replaceState(null, '', '/?variant=' + encodeURIComponent(name));
+      fetch('/select-variant?name=' + encodeURIComponent(name)).catch(() => {});
+    });
+    `
+        : ''
+    }
+  </script>
+</body>
+</html>`;
+}
+
+interface DevServer {
+  close: () => Promise<void>;
+  port: number;
+}
+
+export async function startDevServer(
+  absolutePath: string,
+  options: {
+    port?: number;
+    props?: Record<string, unknown>;
+    variant?: string;
+    manager?: BrowserManager;
+  } = {},
+): Promise<DevServer> {
+  const port = options.port ?? 3000;
+  const props = options.props ?? {};
+  const pinnedVariant = options.variant;
+
+  const manager = options.manager ?? new BrowserManager();
+  const ownsManager = !options.manager;
+  let bannerPrinted = false;
+
+  const state: DevState = {
+    buffers: new Map(),
+    sseClients: [],
+    currentVariant: pinnedVariant ?? null,
+    variants: [],
+    renderTime: 0,
+    compositionWidth: 1200,
+    compositionHeight: 630,
+    compositionScale: 1,
+  };
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let watchers: FSWatcher[] = [];
+  let lastCodeHash = '';
+  let lastErrorHash = '';
+  let renderInProgress = false;
+  let renderQueued = false;
+  let queuedVariant: string | undefined;
+
+  function sendSSE(clients: ServerResponse[], event: string, data: unknown): void {
+    const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const client of clients) {
+      try {
+        client.write(payload);
+      } catch {
+        // ignore disconnected clients
+      }
+    }
+  }
+
+  async function doRender(variant?: string): Promise<void> {
+    if (renderInProgress) {
+      renderQueued = true;
+      queuedVariant = variant;
+      return;
+    }
+    renderInProgress = true;
+    try {
+      const start = Date.now();
+      try {
+        const { code, inputs } = await transpile(absolutePath, true);
+
+        const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}#${Date.now()}`;
+        const mod = await import(dataUrl);
+
+        const component = mod.default as (props: Record<string, unknown>) => unknown;
+        const config: CompositionConfig = mod.config ?? {};
+
+        const compositionDir = dirname(absolutePath);
+        const width = config.width ?? 1200;
+        const height = config.height ?? 630;
+        const scale = config.scale ?? 1;
+
+        state.compositionWidth = width;
+        state.compositionHeight = height;
+        state.compositionScale = scale;
+
+        // Determine variants — detect config structure changes
+        const configVariants: string[] = config.variants ? Object.keys(config.variants) : [];
+        const prevVariants = state.variants;
+        const variantsChanged =
+          prevVariants.length !== configVariants.length ||
+          prevVariants.some((v, i) => v !== configVariants[i]);
+        state.variants = configVariants;
+
+        // Determine active variant
+        let activeVariant = variant ?? state.currentVariant;
+        if (configVariants.length > 0) {
+          if (!activeVariant || !configVariants.includes(activeVariant)) {
+            activeVariant = configVariants[0];
+          }
+        } else {
+          activeVariant = null;
+        }
+        state.currentVariant = activeVariant;
+
+        // Resolve variant config if applicable
+        let variantProps = props;
+        if (activeVariant && config.variants) {
+          const variantDef = config.variants[activeVariant];
+          if (variantDef?.props) {
+            variantProps = { ...props, ...variantDef.props };
+          }
+        }
+
+        // Read CSS files
+        const cssContents: string[] = [];
+        const cssPaths: string[] = [];
+        if (config.css && config.css.length > 0) {
+          for (const cssPath of config.css) {
+            const resolvedCssPath = resolve(compositionDir, cssPath);
+            cssPaths.push(resolvedCssPath);
+            let rawCss: string;
+            try {
+              rawCss = await readFile(resolvedCssPath, 'utf-8');
+            } catch {
+              throw new Error(
+                `CSS file not found: "${resolvedCssPath}" (referenced in ${absolutePath})`,
+              );
+            }
+            cssContents.push(await embedCssAssets(rawCss, dirname(resolvedCssPath)));
+          }
+        }
+
+        // Skip re-render if inputs haven't changed (macOS fs.watch fires multiple events per save)
+        // Include activeVariant so switching variants always triggers a render even when code is unchanged
+        const contentHash = code + cssContents.join('') + (activeVariant ?? '');
+        if (contentHash === lastCodeHash && bannerPrinted) {
+          pendingChangeFile = null;
+          return; // finally block still runs — renderInProgress will be cleared
+        }
+        lastCodeHash = contentHash;
+        lastErrorHash = '';
+
+        // Log the change that triggered this render (only when content actually changed)
+        if (pendingChangeFile) {
+          logChange(pendingChangeFile);
+          pendingChangeFile = null;
+        }
+
+        const componentHtml = String(component(variantProps));
+        const rawHtml = renderToHTML(componentHtml, { width, height }, config.fonts, cssContents);
+        const html = await embedLocalAssets(rawHtml, compositionDir);
+
+        const buffer = await manager.render(html, { width, height }, scale, 'png', undefined);
+        state.buffers.set(activeVariant ?? '', buffer);
+        state.renderTime = Date.now() - start;
+        if (!bannerPrinted) {
+          bannerPrinted = true;
+          logBanner({
+            version: pkg.version,
+            file: basename(absolutePath),
+            port,
+            variants: state.variants.length > 0 ? state.variants : undefined,
+            currentVariant: state.currentVariant,
+            width,
+            height,
+            scale,
+            renderTime: state.renderTime,
+          });
+        } else {
+          logRender({ width, height, scale, ms: state.renderTime, variant: activeVariant });
+        }
+
+        // Rebuild watchers
+        const watchFiles = buildWatchList(absolutePath, inputs, cssPaths);
+        rebuildWatchers(watchFiles);
+
+        if (variantsChanged) {
+          sendSSE(state.sseClients, 'reload', {});
+        } else {
+          sendSSE(state.sseClients, 'render', {
+            timestamp: Date.now(),
+            renderTime: state.renderTime,
+            variant: state.currentVariant,
+            width,
+            height,
+            scale,
+          });
+        }
+      } catch (err) {
+        const message = (err as Error).message ?? String(err);
+
+        // Skip duplicate errors from fs.watch event spam
+        if (message === lastErrorHash) {
+          pendingChangeFile = null;
+          return;
+        }
+        lastErrorHash = message;
+        lastCodeHash = ''; // Clear so fixing the error triggers a render
+
+        // Log the change that triggered this error
+        if (pendingChangeFile) {
+          logChange(pendingChangeFile);
+          pendingChangeFile = null;
+        }
+
+        logError(message);
+        sendSSE(state.sseClients, 'error_event', { message, timestamp: Date.now() });
+      }
+    } finally {
+      renderInProgress = false;
+      if (renderQueued) {
+        renderQueued = false;
+        void doRender(queuedVariant);
+      }
+    }
+  }
+
+  let pendingChangeFile: string | null = null;
+
+  function scheduleRender(variant?: string, changedFile?: string): void {
+    if (changedFile) pendingChangeFile = changedFile;
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void doRender(variant);
+    }, 100);
+  }
+
+  function rebuildWatchers(files: Set<string>): void {
+    for (const w of watchers) {
+      try {
+        w.close();
+      } catch {
+        // ignore
+      }
+    }
+    watchers = [];
+
+    for (const file of files) {
+      try {
+        const watcher = watch(file, () => {
+          scheduleRender(undefined, basename(file));
+        });
+        watchers.push(watcher);
+      } catch {
+        // ignore files we can't watch
+      }
+    }
+  }
+
+  function handleRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+
+    if (url.pathname === '/') {
+      const html = previewHtml(absolutePath.split('/').pop() ?? absolutePath, state, pinnedVariant);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+      return;
+    }
+
+    if (url.pathname === '/image') {
+      const requestedVariant = url.searchParams.get('variant') ?? state.currentVariant ?? undefined;
+      const bufferKey = requestedVariant ?? '';
+      const buffer = state.buffers.get(bufferKey);
+      if (buffer) {
+        res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' });
+        res.end(buffer);
+      } else if (state.buffers.size > 0) {
+        // Requested variant not yet rendered — trigger async re-render and serve a cached buffer
+        void doRender(requestedVariant);
+        const fallback =
+          state.buffers.get(state.currentVariant ?? '') ?? state.buffers.values().next().value!;
+        res.writeHead(200, { 'Content-Type': 'image/png', 'Cache-Control': 'no-store' });
+        res.end(fallback);
+      } else {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('Not ready yet');
+      }
+      return;
+    }
+
+    if (url.pathname === '/events') {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      });
+      res.write(':\n\n'); // comment to establish connection
+      state.sseClients.push(res);
+
+      req.on('close', () => {
+        const idx = state.sseClients.indexOf(res);
+        if (idx !== -1) state.sseClients.splice(idx, 1);
+      });
+      return;
+    }
+
+    if (url.pathname === '/select-variant') {
+      const name = url.searchParams.get('name');
+      if (name && state.variants.includes(name)) {
+        state.currentVariant = name;
+        void doRender(name);
+      }
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not found');
+  }
+
+  const server = createServer(handleRequest);
+
+  await new Promise<void>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(port, () => resolve());
+  });
+
+  const actualPort = (server.address() as { port: number }).port;
+  // Banner will be printed after first render completes (logBanner needs dimensions)
+
+  // Initial render (don't await — let it run in background while server is up)
+  void doRender();
+
+  return {
+    port: actualPort,
+    close: async () => {
+      if (debounceTimer !== null) {
+        clearTimeout(debounceTimer);
+      }
+      for (const w of watchers) {
+        try {
+          w.close();
+        } catch {
+          // ignore
+        }
+      }
+      for (const client of state.sseClients) {
+        try {
+          client.end();
+        } catch {
+          // ignore
+        }
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      if (ownsManager) {
+        await manager.close();
+      }
+    },
+  };
+}
+
+export async function runDev(args: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args,
+    options: {
+      file: { type: 'string', short: 'f' },
+      port: { type: 'string' },
+      props: { type: 'string' },
+      variant: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    strict: false,
+  });
+
+  if (values.help) {
+    process.stdout.write(HELP + '\n');
+    process.exit(0);
+  }
+
+  if (!values.file) {
+    process.stderr.write('Error: --file (-f) is required.\n');
+    process.exit(1);
+  }
+
+  let port = 3000;
+  if (values.port !== undefined) {
+    const n = Number(values.port as string);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      process.stdout.write(
+        `Error: --port must be an integer between 1 and 65535, got "${values.port}".\n`,
+      );
+      process.exit(1);
+    }
+    port = n;
+  }
+
+  let props: Record<string, unknown> = {};
+  if (values.props !== undefined) {
+    try {
+      props = JSON.parse(values.props as string);
+    } catch (err) {
+      process.stdout.write(`Invalid JSON in --props: ${(err as Error).message}\n`);
+      process.exit(1);
+    }
+  }
+
+  const absolutePath = resolve(values.file as string);
+  const url = `http://localhost:${port}`;
+
+  const dev = await startDevServer(absolutePath, {
+    port,
+    props,
+    variant: values.variant as string | undefined,
+  });
+
+  openBrowser(url);
+
+  const shutdown = async () => {
+    process.stdout.write('\n  Shutting down...\n');
+    await dev.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => void shutdown());
+  process.on('SIGTERM', () => void shutdown());
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,86 @@
+const useColor = !process.env.NO_COLOR && process.stderr.isTTY !== false;
+
+const c = (code: string, text: string): string => (useColor ? `\x1b[${code}m${text}\x1b[0m` : text);
+
+const cyan = (s: string) => c('36', s);
+const boldCyan = (s: string) => c('1;36', s);
+const green = (s: string) => c('32', s);
+const boldGreen = (s: string) => c('1;32', s);
+const yellow = (s: string) => c('33', s);
+const red = (s: string) => c('31', s);
+const dim = (s: string) => c('2', s);
+const bold = (s: string) => c('1;37', s);
+const white = (s: string) => c('37', s);
+
+function pad(label: string, width: number): string {
+  return label + ' '.repeat(Math.max(1, width - label.length));
+}
+
+function renderTimeColor(ms: number): string {
+  if (ms < 200) return green(`${ms}ms`);
+  if (ms <= 1000) return yellow(`${ms}ms`);
+  return red(`${ms}ms`);
+}
+
+export function logBanner(opts: {
+  version: string;
+  file: string;
+  port: number;
+  variants?: string[];
+  currentVariant?: string | null;
+  width?: number;
+  height?: number;
+  scale?: number;
+  renderTime: number;
+}): void {
+  const lines: string[] = [''];
+  lines.push(`  ${boldCyan('grafex')} ${dim(`v${opts.version}`)}`);
+  lines.push('');
+  lines.push(`  ${bold(pad('watching', 11))}${cyan(opts.file)}`);
+  lines.push(`  ${bold(pad('preview', 11))}${cyan(`http://localhost:${opts.port}/`)}`);
+
+  if (opts.variants && opts.variants.length > 0) {
+    const names = opts.variants
+      .map((v) => (v === opts.currentVariant ? bold(v) : white(v)))
+      .join(dim(', '));
+    lines.push(`  ${bold(pad('variants', 11))}${names}`);
+  } else if (opts.width && opts.height) {
+    const scaleStr = opts.scale && opts.scale !== 1 ? dim(` @ ${opts.scale}x`) : '';
+    lines.push(`  ${bold(pad('size', 11))}${white(`${opts.width}x${opts.height}`)}${scaleStr}`);
+  }
+
+  lines.push('');
+  lines.push(`  ${dim('ready in')} ${boldGreen(`${opts.renderTime}ms`)}`);
+  lines.push('');
+  process.stderr.write(lines.join('\n'));
+}
+
+export function logRender(opts: {
+  width: number;
+  height: number;
+  ms: number;
+  scale?: number;
+  variant?: string | null;
+}): void {
+  const variant = opts.variant ? `${white(opts.variant)} ` : '';
+  const scaleStr = dim(` @ ${opts.scale ?? 1}x`);
+  process.stderr.write(
+    `  ${green(pad('render', 9))}${variant}${dim(`${opts.width}x${opts.height}`)}${scaleStr} ${renderTimeColor(opts.ms)}\n`,
+  );
+}
+
+export function logChange(file: string): void {
+  process.stderr.write(`  ${dim(pad('change', 9))}${white(file)}\n`);
+}
+
+export function logVariant(name: string, width: number, height: number): void {
+  process.stderr.write(`  ${cyan(pad('variant', 9))}${bold(name)} ${dim(`${width}x${height}`)}\n`);
+}
+
+export function logError(message: string): void {
+  process.stderr.write(`  ${red(pad('error', 9))}${red(message)}\n`);
+}
+
+export function logWarn(message: string): void {
+  process.stderr.write(`  ${yellow(pad('warn', 9))}${yellow(message)}\n`);
+}

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -13,7 +13,20 @@ export function resolveRuntimePath(dir: string = __dirname): string {
   throw new Error(`Grafex runtime not found. Expected runtime.js or runtime.ts at: ${dir}`);
 }
 
-export async function transpile(compositionPath: string): Promise<string> {
+export interface TranspileResult {
+  code: string;
+  inputs: string[];
+}
+
+export async function transpile(compositionPath: string): Promise<string>;
+export async function transpile(
+  compositionPath: string,
+  withMetafile: true,
+): Promise<TranspileResult>;
+export async function transpile(
+  compositionPath: string,
+  withMetafile?: boolean,
+): Promise<string | TranspileResult> {
   const absolutePath = resolve(compositionPath);
   const runtimePath = resolveRuntimePath();
 
@@ -30,6 +43,8 @@ export async function transpile(compositionPath: string): Promise<string> {
       platform: 'node',
       target: 'node18',
       loader: { '.ts': 'ts', '.tsx': 'tsx' },
+      metafile: withMetafile ?? false,
+      logLevel: 'silent',
       tsconfigRaw: {
         compilerOptions: {
           jsx: 'react',
@@ -39,8 +54,23 @@ export async function transpile(compositionPath: string): Promise<string> {
       },
     });
   } catch (err) {
+    const buildErr = err as {
+      errors?: Array<{ text: string; location?: { file: string; line: number; column: number } }>;
+    };
+    if (buildErr.errors?.length) {
+      const e = buildErr.errors[0];
+      const loc = e.location ? `${e.location.file}:${e.location.line}:${e.location.column}: ` : '';
+      throw new Error(`${loc}${e.text}`);
+    }
     throw new Error(`esbuild transpilation failed:\n${(err as Error).message}`);
   }
 
-  return result.outputFiles[0].text;
+  const code = result.outputFiles[0].text;
+
+  if (withMetafile) {
+    const inputs = Object.keys(result.metafile!.inputs).map((p) => resolve(p));
+    return { code, inputs };
+  }
+
+  return code;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,3 @@
-export interface VariantConfig {
-  width?: number;
-  height?: number;
-  scale?: number;
-  format?: 'png' | 'jpeg';
-  quality?: number;
-  fonts?: string[];
-  css?: string[];
-  props?: Record<string, unknown>;
-}
-
 export interface RenderOptions {
   props?: Record<string, unknown>;
   width?: number;
@@ -26,6 +15,17 @@ export interface RenderResult {
   height: number;
   scale: number;
   format: 'png' | 'jpeg';
+}
+
+export interface VariantConfig {
+  width?: number;
+  height?: number;
+  scale?: number;
+  format?: 'png' | 'jpeg';
+  quality?: number;
+  fonts?: string[];
+  css?: string[];
+  props?: Record<string, unknown>;
 }
 
 export interface CompositionConfig {

--- a/test/integration/dev.test.ts
+++ b/test/integration/dev.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { get } from 'node:http';
+import { startDevServer } from '../../src/commands/dev.js';
+import { BrowserManager } from '../../src/browser.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = resolve(__dirname, '../fixtures/simple.tsx');
+
+let devServer: Awaited<ReturnType<typeof startDevServer>>;
+let manager: BrowserManager;
+
+function httpGet(url: string): Promise<{
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: Buffer;
+}> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const req = get(url, (res) => {
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          headers: res.headers as Record<string, string | string[] | undefined>,
+          body: Buffer.concat(chunks),
+        });
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.setTimeout(5000, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+  });
+}
+
+function httpGetStream(
+  url: string,
+  timeout: number,
+): Promise<{ status: number; headers: Record<string, string | string[] | undefined> }> {
+  return new Promise((resolve, reject) => {
+    const req = get(url, (res) => {
+      // Immediately resolve once headers arrive — don't wait for body (SSE stream is long-lived)
+      resolve({
+        status: res.statusCode ?? 0,
+        headers: res.headers as Record<string, string | string[] | undefined>,
+      });
+      res.resume(); // drain to avoid memory buildup
+    });
+    req.on('error', reject);
+    req.setTimeout(timeout, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+  });
+}
+
+beforeAll(async () => {
+  manager = new BrowserManager();
+  devServer = await startDevServer(fixturePath, { port: 0, manager });
+
+  // Wait for initial render to complete (up to 30s)
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await httpGet(`http://localhost:${devServer.port}/image`);
+      if (res.status === 200) break;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+}, 60_000);
+
+afterAll(async () => {
+  await devServer.close();
+  await manager.close();
+}, 15_000);
+
+describe('dev server — HTTP endpoints', () => {
+  test('GET / returns 200 with HTML containing <img>', async () => {
+    const res = await httpGet(`http://localhost:${devServer.port}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+    const body = res.body.toString('utf-8');
+    expect(body).toContain('<img');
+  }, 10_000);
+
+  test('GET /image returns 200 with PNG buffer', async () => {
+    const res = await httpGet(`http://localhost:${devServer.port}/image`);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/png');
+    // PNG magic bytes: 0x89 0x50 0x4E 0x47
+    expect(res.body[0]).toBe(0x89);
+    expect(res.body[1]).toBe(0x50);
+    expect(res.body[2]).toBe(0x4e);
+    expect(res.body[3]).toBe(0x47);
+  }, 10_000);
+
+  test('GET /events returns 200 with SSE content-type', async () => {
+    const res = await httpGetStream(`http://localhost:${devServer.port}/events`, 5000);
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+  }, 10_000);
+
+  test('GET /unknown returns 404', async () => {
+    const res = await httpGet(`http://localhost:${devServer.port}/unknown`);
+    expect(res.status).toBe(404);
+  }, 10_000);
+});
+
+describe('dev server — cleanup', () => {
+  test('close() resolves without throwing', async () => {
+    // We create a separate server to test close() in isolation
+    const m2 = new BrowserManager();
+    const s = await startDevServer(fixturePath, { port: 0, manager: m2 });
+    await expect(s.close()).resolves.not.toThrow();
+    await m2.close();
+  }, 30_000);
+});

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -67,6 +67,27 @@ describe('cli — subcommand routing', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('--file');
   });
+
+  test('--help lists the dev command', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('dev');
+  });
+});
+
+describe('dev command — validation', () => {
+  test('dev --help exits 0 and shows dev help text', () => {
+    const result = runCli(['dev', '--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('--file');
+    expect(result.stdout).toContain('--port');
+  });
+
+  test('dev without --file exits 1', () => {
+    const result = runCli(['dev']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('--file');
+  });
 });
 
 describe('export command — validation', () => {

--- a/test/unit/transpile.test.ts
+++ b/test/unit/transpile.test.ts
@@ -66,11 +66,11 @@ describe('transpile — error propagation', () => {
     }
   });
 
-  test('error message contains custom prefix "esbuild transpilation failed:"', async () => {
+  test('error message contains the esbuild error text', async () => {
     const tmpFile = join(tmpdir(), `grafex-test-invalid-${Date.now()}.tsx`);
     writeFileSync(tmpFile, 'const x: = 5;');
     try {
-      await expect(transpile(tmpFile)).rejects.toThrow('esbuild transpilation failed:');
+      await expect(transpile(tmpFile)).rejects.toThrow('Unexpected');
     } finally {
       unlinkSync(tmpFile);
     }

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -259,6 +259,32 @@ grafex export -f card.tsx --variant twitter -o twitter.png
 
 Exit codes: 0 = success, 1 = error.
 
+### `grafex dev`
+
+Start a live preview server that watches your composition and re-renders on every file change.
+
+```bash
+grafex dev -f <file> [options]
+```
+
+| Flag | Short | Type | Default | Description |
+|---|---|---|---|---|
+| `--file` | `-f` | string | — | Path to the `.tsx` composition file (required) |
+| `--port` | | number | `3000` | Preview server port |
+| `--props` | | string (JSON) | `{}` | Props to pass to the composition |
+| `--variant` | | string | (first) | Show only the named variant (when composition has variants) |
+| `--help` | `-h` | | | Show help text |
+
+The dev server watches the composition file, all its imports, CSS files from `config.css`, and local image assets. Changes are debounced and the preview updates within ~100ms. Open `http://localhost:3000` to see the live preview. Press Ctrl+C to stop.
+
+Examples:
+
+```bash
+grafex dev -f card.tsx
+grafex dev -f card.tsx --port 8080
+grafex dev -f card.tsx --props '{"title":"Hello"}'
+```
+
 ### Global Flags
 
 ```bash

--- a/website/src/pages/docs/cli.astro
+++ b/website/src/pages/docs/cli.astro
@@ -132,6 +132,61 @@ grafex --help       # Print help text and exit`;
       </div>
     </section>
 
+    <!-- grafex dev -->
+    <section class="mb-12">
+      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">grafex dev</code></h2>
+      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Start a live preview server that watches your composition and re-renders on every file change.</p>
+
+      <div class="rounded-xl overflow-hidden border mb-8" style="border-color: var(--color-border-default);">
+        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
+          <CopyButton text="grafex dev -f <file> [options]" client:load />
+        </div>
+        <div class="px-4 py-3" style="background: var(--color-bg-code);">
+          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex dev -f &lt;file&gt; [options]</code>
+        </div>
+      </div>
+
+      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">Flags</h3>
+
+      <div class="rounded-xl overflow-hidden border mb-8" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
+                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Flag</th>
+                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Short</th>
+                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Type</th>
+                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Default</th>
+                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                ['--file', '-f', 'string', '—', 'Path to the .tsx composition file (required)'],
+                ['--port', '', 'number', '3000', 'Preview server port'],
+                ['--props', '', 'string (JSON)', '{}', 'Props to pass to the composition as a JSON object'],
+                ['--variant', '', 'string', '(first)', 'Show only the named variant (when composition has variants)'],
+                ['--help', '-h', '', '', 'Show help text'],
+              ].map(([flag, short, type, def, desc]) => (
+                <tr style="border-bottom: 1px solid var(--color-border-default);">
+                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-primary);">{flag}</code></td>
+                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: short ? 'var(--color-secondary)' : 'var(--color-text-muted)'">{short || '—'}</code></td>
+                  <td class="px-4 py-3 text-xs" style="color: var(--color-text-muted);">{type || '—'}</td>
+                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-accent-lime);">{def}</code></td>
+                  <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">
+        The dev server watches the composition file, all its imports, CSS files from <code class="font-mono text-xs" style="color: var(--color-primary);">config.css</code>, and local image assets. Changes are debounced and the preview updates within ~100ms. Press <kbd style="background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 4px; padding: 1px 5px; font-size: 11px;">Ctrl+C</kbd> to stop.
+      </p>
+    </section>
+
     <!-- Global Flags -->
     <section>
       <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Global Flags</h2>


### PR DESCRIPTION
## Summary

- `grafex dev --file card.tsx` starts a live preview server
- SSE-based instant updates on file changes (no page reload)
- Watches composition file, imports (via esbuild metafile), and CSS files
- Variant switcher dropdown when composition has `config.variants`
- Colored terminal output: render times (green/yellow/red), file changes, errors
- Error overlay in browser preview, error dedup in terminal
- Content hash deduplication for macOS fs.watch duplicate events
- Render-in-progress mutex prevents concurrent renders
- Loading placeholder sized to composition dimensions
- `--variant` flag sets initial variant (dropdown still available)

Closes #29

## Test plan

- [x] 287 tests pass
- [x] Live preview updates on file changes
- [x] Variant switching works in UI and terminal
- [x] Syntax errors show in both terminal and browser overlay
- [x] Recovery from errors works (fix and save)
- [x] Colored render times in terminal and browser
- [x] No duplicate logs from macOS fs.watch
- [x] Ctrl+C shuts down cleanly