### PR TITLE
refactor(website): Tailwind theme migration and component cleanup

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17,10 +17,63 @@
         "astro": "^6.0.5",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.1"
+      },
+      "devDependencies": {
+        "@astrojs/check": "^0.9.8"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.8.tgz",
+      "integrity": "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.5",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -37,6 +90,55 @@
       "dependencies": {
         "picomatch": "^4.0.3"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.6.tgz",
+      "integrity": "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.15",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.0.0",
@@ -127,6 +229,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -450,6 +562,68 @@
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.0",
@@ -2305,6 +2479,163 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2600,6 +2931,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2608,6 +2954,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2927,6 +3293,30 @@
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "license": "ISC"
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -3038,6 +3428,30 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3106,6 +3520,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/github-slugger": {
@@ -3360,6 +3784,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -3444,6 +3878,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3452,6 +3893,23 @@
       "bin": {
         "json5": "lib/cli.js"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4563,6 +5021,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4765,6 +5230,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4815,6 +5287,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -5051,6 +5540,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/retext": {
@@ -5312,6 +5828,21 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5324,6 +5855,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -5349,6 +5893,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {
@@ -5456,6 +6010,38 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -5896,6 +6482,261 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -5915,17 +6756,124 @@
         "node": ">=4"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "devOptional": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
@@ -5934,6 +6882,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "typecheck": "astro check"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
@@ -21,6 +22,10 @@
     "astro": "^6.0.5",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.1"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.8"
   }
 }

--- a/website/src/components/Callout.astro
+++ b/website/src/components/Callout.astro
@@ -1,0 +1,23 @@
+---
+import { cn } from '../lib/cn';
+
+interface Props {
+  type: 'lime' | 'amber' | 'sky';
+  label: string;
+  class?: string;
+}
+
+const { type, label, class: extraClass } = Astro.props;
+
+const styles: Record<string, string> = {
+  lime: 'bg-lime-muted border-l-lime',
+  amber: 'bg-amber-muted border-l-amber',
+  sky: 'bg-sky-muted border-l-sky',
+};
+---
+
+<div class={cn('rounded-xl p-4 border-l-4', styles[type], extraClass)}>
+  <p class="text-sm leading-relaxed text-heading">
+    <span class={cn('font-semibold', `text-${type}`)}>{label} </span><slot />
+  </p>
+</div>

--- a/website/src/components/CodeBlock.astro
+++ b/website/src/components/CodeBlock.astro
@@ -1,35 +1,63 @@
 ---
 import { Code } from 'astro:components';
+import type { CodeLanguage } from 'astro';
 import CopyButton from './CopyButton.tsx';
 import { grafexTheme } from '../shiki-theme';
+import { cn } from '../lib/cn';
 
 interface Props {
   code: string;
-  lang?: string;
-  filename?: string;
+  lang?: CodeLanguage;
+  label?: string;
   showCopy?: boolean;
   maxHeight?: string;
+  collapsible?: boolean;
+  class?: string;
 }
 
-const { code, lang = 'typescript', filename, showCopy = true, maxHeight = '500px' } = Astro.props;
+const {
+  code,
+  lang = 'typescript',
+  label,
+  showCopy = true,
+  maxHeight = '500px',
+  collapsible = false,
+  class: className,
+} = Astro.props;
+
+const showHeader = !!label || showCopy;
+const headerLabel = label ?? String(lang);
+const wrapperClass = cn('rounded-xl overflow-hidden border border-edge mb-4', className);
+const bodyClass =
+  'overflow-x-auto text-left [&_pre]:p-4 [&_pre]:!bg-codeblock [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed';
+const bodyStyle = `max-height: ${maxHeight}; overflow-y: auto;`;
 ---
 
-<div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-  {filename && (
-    <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-      <span class="text-xs font-mono" style="color: var(--color-text-muted);">{filename}</span>
+{collapsible ? (
+  <details class={cn('group', wrapperClass)}>
+    <summary class="flex items-center justify-between px-4 py-2 cursor-pointer select-none hover:bg-surface-hover transition-colors list-none [&::-webkit-details-marker]:hidden bg-surface border-b border-edge">
+      <div class="flex items-center gap-3">
+        <svg class="w-4 h-4 transition-transform duration-200 group-open:rotate-90 text-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <polyline points="9 6 15 12 9 18" />
+        </svg>
+        <span class="text-xs font-mono text-muted">{headerLabel}</span>
+      </div>
       {showCopy && <CopyButton text={code} client:load />}
+    </summary>
+    <div class={bodyClass} style={bodyStyle}>
+      <Code code={code} lang={lang} theme={grafexTheme} />
     </div>
-  )}
-  {!filename && showCopy && (
-    <div class="flex items-center justify-end px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-      <CopyButton text={code} client:load />
+  </details>
+) : (
+  <div class={wrapperClass}>
+    {showHeader && (
+      <div class="flex items-center justify-between px-4 py-2 border-b bg-surface border-edge">
+        <span class="text-xs font-mono text-muted">{headerLabel}</span>
+        {showCopy && <CopyButton text={code} client:load />}
+      </div>
+    )}
+    <div class={bodyClass} style={bodyStyle}>
+      <Code code={code} lang={lang} theme={grafexTheme} />
     </div>
-  )}
-  <div
-    class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed"
-    style={`max-height: ${maxHeight}; overflow-y: auto;`}
-  >
-    <Code code={code} lang={lang} theme={grafexTheme} />
   </div>
-</div>
+)}

--- a/website/src/components/CopyButton.tsx
+++ b/website/src/components/CopyButton.tsx
@@ -7,7 +7,6 @@ interface Props {
 
 export default function CopyButton({ text, className = '' }: Props) {
   const [copied, setCopied] = useState(false);
-  const [hovered, setHovered] = useState(false);
 
   const handleCopy = async () => {
     try {
@@ -19,20 +18,13 @@ export default function CopyButton({ text, className = '' }: Props) {
     }
   };
 
-  const color = copied
-    ? 'var(--color-accent-lime)'
-    : hovered
-      ? 'var(--color-text-primary)'
-      : 'var(--color-text-muted)';
-
   return (
     <button
       onClick={handleCopy}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
       aria-label={copied ? 'Copied!' : 'Copy to clipboard'}
-      className={`p-1.5 rounded transition-colors cursor-pointer ${className}`}
-      style={{ color }}
+      className={`p-1.5 rounded transition-colors cursor-pointer ${
+        copied ? 'text-lime' : 'text-muted hover:text-heading'
+      } ${className}`}
     >
       {copied ? (
         <svg

--- a/website/src/components/InlineCode.astro
+++ b/website/src/components/InlineCode.astro
@@ -1,0 +1,3 @@
+---
+---
+<code class="font-mono text-sm text-pink bg-pink-muted px-1.5 py-0.5 rounded"><slot /></code>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -24,19 +24,19 @@ const navItems = [
   <!-- Skip to content -->
   <a
     href="#main-content"
-    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:text-[var(--color-text-primary)] focus:bg-[var(--color-bg-surface)] focus:outline-2 focus:outline-[var(--color-border-focus)]"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
   >
     Skip to content
   </a>
 
   <!-- Top bar -->
-  <header class="fixed top-0 left-0 right-0 z-40 h-16 border-b border-[var(--color-border-default)] bg-[var(--color-bg-base)]/90 backdrop-blur-md">
+  <header class="fixed top-0 left-0 right-0 z-40 h-16 border-b border-edge bg-base/90 backdrop-blur-md">
     <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
       <div class="flex items-center gap-8">
         <!-- Mobile menu button -->
         <button
           id="docs-menu-btn"
-          class="md:hidden p-2 rounded-md text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface)] transition-colors"
+          class="md:hidden p-2 rounded-md text-body hover:text-heading hover:bg-surface transition-colors"
           aria-label="Open navigation menu"
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
@@ -45,15 +45,15 @@ const navItems = [
             <line x1="3" y1="18" x2="21" y2="18"/>
           </svg>
         </button>
-        <a href="/" class="font-heading font-bold text-xl text-[var(--color-text-primary)] transition-opacity duration-150 ease-out hover:opacity-80">Grafex</a>
-        <span class="hidden md:block text-[var(--color-border-strong)]">/</span>
-        <span class="hidden md:block text-sm text-[var(--color-text-secondary)]">Docs</span>
+        <a href="/" class="font-heading font-bold text-xl text-heading transition-opacity duration-150 ease-out hover:opacity-80">Grafex</a>
+        <span class="hidden md:block text-edge-strong">/</span>
+        <span class="hidden md:block text-sm text-body">Docs</span>
       </div>
       <a
         href="https://github.com/grafex-dev/grafex"
         target="_blank"
         rel="noopener noreferrer"
-        class="flex items-center gap-2 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
+        class="flex items-center gap-2 text-sm text-body hover:text-heading transition-colors"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
@@ -70,7 +70,7 @@ const navItems = [
     <!-- Sidebar -->
     <aside
       id="docs-sidebar"
-      class="fixed left-0 top-16 bottom-0 w-64 z-30 border-r border-[var(--color-border-default)] bg-[var(--color-bg-base)] overflow-y-auto transform -translate-x-full md:translate-x-0 transition-transform duration-200"
+      class="fixed left-0 top-16 bottom-0 w-64 z-30 border-r border-edge bg-base overflow-y-auto transform -translate-x-full md:translate-x-0 transition-transform duration-200"
     >
       <nav class="p-6">
         <ul class="space-y-1">
@@ -82,8 +82,8 @@ const navItems = [
                   href={item.href}
                   class={`block px-3 py-2 rounded-md text-sm transition-colors ${
                     isActive
-                      ? 'text-[var(--color-text-primary)] bg-[rgba(244,114,182,0.1)] border-l-2 border-[var(--color-primary)] pl-[10px]'
-                      : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-hover)]'
+                      ? 'text-heading bg-pink-muted border-l-2 border-pink pl-[10px]'
+                      : 'text-body hover:text-heading hover:bg-surface-hover'
                   }`}
                 >
                   {item.label}

--- a/website/src/layouts/MarketingLayout.astro
+++ b/website/src/layouts/MarketingLayout.astro
@@ -1,0 +1,126 @@
+---
+import BaseLayout from './BaseLayout.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+  ogImage?: string;
+}
+
+const {
+  title,
+  description = 'Grafex — programmatic image composition. Images as code.',
+  ogImage,
+} = Astro.props;
+---
+
+<BaseLayout title={title} description={description} ogImage={ogImage}>
+  <!-- Skip to content -->
+  <a
+    href="#main-content"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
+  >
+    Skip to content
+  </a>
+
+  <!-- Navigation -->
+  <header id="site-nav" class="fixed top-0 left-0 right-0 z-40 h-16 transition-all duration-300 border-b border-transparent">
+    <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
+      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-heading">Grafex</a>
+
+      <!-- Desktop nav -->
+      <nav class="hidden md:flex items-center gap-8">
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="/#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
+        <a href="/#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+      </nav>
+
+      <div class="hidden md:block">
+        <a
+          href="/docs/getting-started"
+          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 gradient-cta"
+        >
+          Get Started
+        </a>
+      </div>
+
+      <!-- Mobile hamburger -->
+      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors text-body" aria-label="Open menu" aria-expanded="false">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+          <line x1="3" y1="6" x2="21" y2="6"/>
+          <line x1="3" y1="12" x2="21" y2="12"/>
+          <line x1="3" y1="18" x2="21" y2="18"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Mobile menu -->
+    <div id="mobile-menu" class="hidden md:hidden border-t bg-base border-edge">
+      <nav class="px-6 py-4 flex flex-col gap-4">
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="/#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
+        <a href="/#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta hover:brightness-110 transition-all">
+          Get Started
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <slot />
+  </main>
+
+  <!-- Footer -->
+  <footer class="py-8 px-6 border-t border-edge bg-base">
+    <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
+      <div class="flex items-center gap-3">
+        <span class="text-sm font-semibold text-body">Grafex</span>
+        <span class="text-xs text-muted">MIT License</span>
+      </div>
+      <nav class="flex items-center gap-6">
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('mobile-menu-btn');
+    const mobileMenu = document.getElementById('mobile-menu');
+
+    menuBtn?.addEventListener('click', () => {
+      const isOpen = !mobileMenu?.classList.contains('hidden');
+      mobileMenu?.classList.toggle('hidden');
+      menuBtn.setAttribute('aria-expanded', String(!isOpen));
+    });
+
+    mobileMenu?.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        mobileMenu.classList.add('hidden');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      });
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !mobileMenu?.classList.contains('hidden')) {
+        mobileMenu?.classList.add('hidden');
+        menuBtn?.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    const nav = document.getElementById('site-nav');
+    function updateNav() {
+      if (window.scrollY > 50) {
+        nav?.classList.add('nav-scrolled');
+      } else {
+        nav?.classList.remove('nav-scrolled');
+      }
+    }
+    window.addEventListener('scroll', updateNav, { passive: true });
+    updateNav();
+  </script>
+</BaseLayout>

--- a/website/src/lib/cn.ts
+++ b/website/src/lib/cn.ts
@@ -1,0 +1,9 @@
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * Merge Tailwind class lists intelligently — later classes override earlier ones
+ * when they target the same CSS property.
+ */
+export function cn(...classes: Array<string | undefined | null | false>): string {
+  return twMerge(classes.filter(Boolean).join(' '));
+}

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -1,59 +1,9 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import MarketingLayout from '../layouts/MarketingLayout.astro';
 ---
 
-<BaseLayout title="Page Not Found — Grafex" description="The page you're looking for doesn't exist.">
-  <!-- Skip link -->
-  <a
-    href="#main-content"
-    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-lg focus:text-sm focus:font-semibold focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
-  >
-    Skip to content
-  </a>
-
-  <!-- Navigation -->
-  <header class="fixed top-0 left-0 right-0 z-40 h-16 border-b border-transparent bg-transparent">
-    <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
-      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-heading">Grafex</a>
-
-      <!-- Desktop nav -->
-      <nav class="hidden md:flex items-center gap-8">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-      </nav>
-
-      <div class="hidden md:block">
-        <a
-          href="/docs/getting-started"
-          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 gradient-cta"
-        >
-          Get Started
-        </a>
-      </div>
-
-      <!-- Mobile hamburger -->
-      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors text-body" aria-label="Open menu" aria-expanded="false">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-          <line x1="3" y1="6" x2="21" y2="6"/>
-          <line x1="3" y1="12" x2="21" y2="12"/>
-          <line x1="3" y1="18" x2="21" y2="18"/>
-        </svg>
-      </button>
-    </div>
-
-    <!-- Mobile menu -->
-    <div id="mobile-menu" class="hidden md:hidden border-t bg-base border-edge">
-      <nav class="px-6 py-4 flex flex-col gap-4">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta">
-          Get Started
-        </a>
-      </nav>
-    </div>
-  </header>
-
-  <main id="main-content" class="relative min-h-screen flex items-center justify-center px-4 overflow-hidden">
+<MarketingLayout title="Page Not Found — Grafex" description="The page you're looking for doesn't exist.">
+  <div class="relative min-h-screen flex items-center justify-center px-4 overflow-hidden">
     <!-- Ambient glow -->
     <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(ellipse at 50% 40%, rgba(244, 114, 182, 0.08), transparent 60%);"></div>
     <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(ellipse at 60% 50%, rgba(56, 189, 248, 0.06), transparent 50%);"></div>
@@ -108,45 +58,5 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </a>
       </div>
     </div>
-  </main>
-
-  <!-- Footer -->
-  <footer class="py-8 px-6 border-t border-edge bg-base">
-    <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-      <div class="flex items-center gap-3">
-        <span class="text-sm font-semibold text-body">Grafex</span>
-        <span class="text-xs text-muted">MIT License</span>
-      </div>
-      <nav class="flex items-center gap-6">
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-        <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-      </nav>
-    </div>
-  </footer>
-
-  <script>
-    const menuBtn = document.getElementById('mobile-menu-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-
-    menuBtn?.addEventListener('click', () => {
-      const isOpen = !mobileMenu?.classList.contains('hidden');
-      mobileMenu?.classList.toggle('hidden');
-      menuBtn.setAttribute('aria-expanded', String(!isOpen));
-    });
-
-    mobileMenu?.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => {
-        mobileMenu?.classList.add('hidden');
-        menuBtn?.setAttribute('aria-expanded', 'false');
-      });
-    });
-
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && !mobileMenu?.classList.contains('hidden')) {
-        mobileMenu?.classList.add('hidden');
-        menuBtn?.setAttribute('aria-expanded', 'false');
-      }
-    });
-  </script>
-</BaseLayout>
+  </div>
+</MarketingLayout>

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -6,35 +6,33 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <!-- Skip link -->
   <a
     href="#main-content"
-    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-lg focus:text-sm focus:font-semibold"
-    style="color: var(--color-text-primary); background: var(--color-bg-surface); outline: 2px solid var(--color-border-focus);"
+    class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-lg focus:text-sm focus:font-semibold focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
   >
     Skip to content
   </a>
 
   <!-- Navigation -->
-  <header class="fixed top-0 left-0 right-0 z-40 h-16 border-b border-transparent" style="background: transparent;">
+  <header class="fixed top-0 left-0 right-0 z-40 h-16 border-b border-transparent bg-transparent">
     <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
-      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-[var(--color-text-primary)]">Grafex</a>
+      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-heading">Grafex</a>
 
       <!-- Desktop nav -->
       <nav class="hidden md:flex items-center gap-8">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
       </nav>
 
       <div class="hidden md:block">
         <a
           href="/docs/getting-started"
-          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110"
-          style="background: linear-gradient(135deg, #F472B6, var(--color-purple));"
+          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 gradient-cta"
         >
           Get Started
         </a>
       </div>
 
       <!-- Mobile hamburger -->
-      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors" style="color: var(--color-text-secondary);" aria-label="Open menu" aria-expanded="false">
+      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors text-body" aria-label="Open menu" aria-expanded="false">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
           <line x1="3" y1="6" x2="21" y2="6"/>
           <line x1="3" y1="12" x2="21" y2="12"/>
@@ -44,11 +42,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
 
     <!-- Mobile menu -->
-    <div id="mobile-menu" class="hidden md:hidden border-t" style="background: var(--color-bg-base); border-color: var(--color-border-default);">
+    <div id="mobile-menu" class="hidden md:hidden border-t bg-base border-edge">
       <nav class="px-6 py-4 flex flex-col gap-4">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
-        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center" style="background: linear-gradient(135deg, #F472B6, var(--color-purple));">
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta">
           Get Started
         </a>
       </nav>
@@ -62,27 +60,27 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
     <!-- Floating code fragments (decorative) -->
     <div class="absolute inset-0 pointer-events-none select-none overflow-hidden" aria-hidden="true">
-      <span class="absolute top-[18%] left-[8%] font-mono text-sm opacity-[0.06] text-[var(--color-primary)] rotate-[-12deg] hidden lg:block">&lt;Image /&gt;</span>
-      <span class="absolute top-[28%] right-[10%] font-mono text-sm opacity-[0.06] text-[var(--color-secondary)] rotate-[8deg] hidden lg:block">export default</span>
-      <span class="absolute bottom-[22%] left-[12%] font-mono text-sm opacity-[0.06] text-[var(--color-accent-lime)] rotate-[6deg] hidden lg:block">width: 1200</span>
-      <span class="absolute bottom-[30%] right-[8%] font-mono text-sm opacity-[0.06] text-[var(--color-accent-amber)] rotate-[-4deg] hidden lg:block">render()</span>
+      <span class="absolute top-[18%] left-[8%] font-mono text-sm opacity-[0.06] text-pink rotate-[-12deg] hidden lg:block">&lt;Image /&gt;</span>
+      <span class="absolute top-[28%] right-[10%] font-mono text-sm opacity-[0.06] text-sky rotate-[8deg] hidden lg:block">export default</span>
+      <span class="absolute bottom-[22%] left-[12%] font-mono text-sm opacity-[0.06] text-lime rotate-[6deg] hidden lg:block">width: 1200</span>
+      <span class="absolute bottom-[30%] right-[8%] font-mono text-sm opacity-[0.06] text-amber rotate-[-4deg] hidden lg:block">render()</span>
     </div>
 
     <div class="relative text-center max-w-lg mx-auto">
       <!-- 404 number -->
       <div
-        class="font-heading font-bold leading-none tracking-tighter select-none"
-        style="font-size: clamp(8rem, 20vw, 12rem); background: linear-gradient(135deg, #F472B6, #38BDF8); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;"
+        class="font-heading font-bold leading-none tracking-tighter select-none gradient-text"
+        style="font-size: clamp(8rem, 20vw, 12rem);"
       >
         404
       </div>
 
       <!-- Message -->
-      <h1 class="font-heading font-bold text-2xl sm:text-3xl mt-2 text-[var(--color-text-primary)]">
+      <h1 class="font-heading font-bold text-2xl sm:text-3xl mt-2 text-heading">
         Page not found.
       </h1>
 
-      <p class="mt-4 text-base sm:text-lg leading-relaxed text-[var(--color-text-secondary)] max-w-md mx-auto">
+      <p class="mt-4 text-base sm:text-lg leading-relaxed text-body max-w-md mx-auto">
         The page you're looking for doesn't exist or has been moved. Check the URL or head back to familiar territory.
       </p>
 
@@ -90,8 +88,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
         <a
           href="/"
-          class="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-offset-2"
-          style="background: linear-gradient(135deg, #F472B6, var(--color-purple)); --tw-ring-color: var(--color-border-focus); --tw-ring-offset-color: var(--color-bg-base);"
+          class="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring ring-offset-base gradient-cta"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
@@ -101,8 +98,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </a>
         <a
           href="/docs/getting-started"
-          class="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-medium border transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 text-[var(--color-text-primary)] hover:bg-[var(--color-bg-surface-hover)]"
-          style="border-color: var(--color-border-strong); --tw-ring-color: var(--color-border-focus); --tw-ring-offset-color: var(--color-bg-base);"
+          class="inline-flex items-center gap-2 px-6 py-3 rounded-lg text-sm font-medium border transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-ring ring-offset-base text-heading hover:bg-surface-hover border-edge-strong"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
@@ -115,16 +111,16 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </main>
 
   <!-- Footer -->
-  <footer class="py-8 px-6 border-t" style="border-color: var(--color-border-default); background: var(--color-bg-base);">
+  <footer class="py-8 px-6 border-t border-edge bg-base">
     <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
       <div class="flex items-center gap-3">
-        <span class="text-sm font-semibold" style="color: var(--color-text-secondary);">Grafex</span>
-        <span class="text-xs" style="color: var(--color-text-muted);">MIT License</span>
+        <span class="text-sm font-semibold text-body">Grafex</span>
+        <span class="text-xs text-muted">MIT License</span>
       </div>
       <nav class="flex items-center gap-6">
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
-        <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">npm</a>
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
       </nav>
     </div>
   </footer>

--- a/website/src/pages/docs/api.astro
+++ b/website/src/pages/docs/api.astro
@@ -1,8 +1,8 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import Callout from '../../components/Callout.astro';
+import InlineCode from '../../components/InlineCode.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const importCode = `import { render, renderAll, close } from 'grafex';`;
 
@@ -105,43 +105,27 @@ const closeCallCode = `await close();`;
   currentPage="/docs/api"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">Library API</h1>
-    <p class="text-lg mb-4" style="color: var(--color-text-secondary);">Use Grafex programmatically in your Node.js applications. Useful for build scripts, CI pipelines, and server-side image generation.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">Library API</h1>
+    <p class="text-lg mb-4 text-body">Use Grafex programmatically in your Node.js applications. Useful for build scripts, CI pipelines, and server-side image generation.</p>
 
-    <div class="rounded-xl overflow-hidden border mb-12" style="border-color: var(--color-border-default);">
-      <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-        <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-        <CopyButton text="import { render, renderAll, close } from 'grafex';" client:load />
-      </div>
-      <div class="overflow-x-auto [&_pre]:px-4 [&_pre]:py-3 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-        <Code code={importCode} lang="typescript" theme={grafexTheme} />
-      </div>
-    </div>
+    <CodeBlock lang="typescript" code={importCode} class="mb-12" />
 
     <!-- render() -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">render(compositionPath, options?)</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Render a composition to an image buffer.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">render(compositionPath, options?)</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Render a composition to an image buffer.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={`const result = await render('./card.tsx', {\n  props: { title: 'Hello' },\n  width: 1200,\n  height: 630,\n});`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={renderCallCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" code={renderCallCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-4" style="color: var(--color-text-primary);">Parameters</h3>
-      <div class="rounded-xl overflow-hidden border mb-8" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <h3 class="font-heading font-semibold text-lg mb-4 text-heading">Parameters</h3>
+      <div class="rounded-xl overflow-hidden border mb-8 bg-surface border-edge">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Parameter</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Type</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+              <tr class="bg-surface-hover border-b border-edge">
+                <th class="text-left px-4 py-3 font-semibold text-heading">Parameter</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Type</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Description</th>
               </tr>
             </thead>
             <tbody>
@@ -156,10 +140,10 @@ const closeCallCode = `await close();`;
                 ['options.scale', 'number', 'Device pixel ratio (default: 1)'],
                 ['options.variant', 'string', 'Named variant to render from config.variants'],
               ].map(([param, type, desc]) => (
-                <tr style="border-bottom: 1px solid var(--color-border-default);">
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-primary);">{param}</code></td>
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-secondary);">{type}</code></td>
-                  <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">{desc}</td>
+                <tr class="border-b border-edge">
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-pink">{param}</code></td>
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-sky">{type}</code></td>
+                  <td class="px-4 py-3 text-sm text-body">{desc}</td>
                 </tr>
               ))}
             </tbody>
@@ -167,96 +151,53 @@ const closeCallCode = `await close();`;
         </div>
       </div>
 
-      <h3 class="font-heading font-semibold text-lg mb-4" style="color: var(--color-text-primary);">Return value</h3>
-      <p class="text-sm mb-4" style="color: var(--color-text-secondary);"><code class="font-mono" style="color: var(--color-primary);">render()</code> returns a <code class="font-mono" style="color: var(--color-secondary);">Promise&lt;RenderResult&gt;</code>:</p>
+      <h3 class="font-heading font-semibold text-lg mb-4 text-heading">Return value</h3>
+      <p class="text-sm mb-4 text-body"><InlineCode>render()</InlineCode> returns a <InlineCode>Promise&lt;RenderResult&gt;</InlineCode>:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-8" style="border-color: var(--color-border-default);">
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={renderResultTypeCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" code={renderResultTypeCode} showCopy={false} class="mb-8" />
 
-      <h3 class="font-heading font-semibold text-lg mb-4" style="color: var(--color-text-primary);">Example — write to file</h3>
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={`import { render, close } from 'grafex';\nimport { writeFileSync } from 'node:fs';\n\nconst result = await render('./card.tsx', {\n  props: { title: 'Hello World' },\n});\n\nwriteFileSync('card.png', result.buffer);\nawait close();`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={writeToFileCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <h3 class="font-heading font-semibold text-lg mb-4 text-heading">Example — write to file</h3>
+      <CodeBlock lang="typescript" code={writeToFileCode} />
     </section>
 
     <!-- renderAll() -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">renderAll(compositionPath, options?)</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Render all variants defined in <code class="font-mono text-sm" style="color: var(--color-primary);">config.variants</code>. Returns a <code class="font-mono text-sm" style="color: var(--color-secondary);">Map&lt;string, RenderResult&gt;</code> keyed by variant name. Throws if the composition has no variants defined.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">renderAll(compositionPath, options?)</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Render all variants defined in <InlineCode>config.variants</InlineCode>. Returns a <InlineCode>Map&lt;string, RenderResult&gt;</InlineCode> keyed by variant name. Throws if the composition has no variants defined.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={renderAllCallCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={renderAllCallCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" code={renderAllCallCode} class="mb-6" />
 
-      <p class="text-sm mb-4" style="color: var(--color-text-secondary);">Accepts the same options as <code class="font-mono" style="color: var(--color-primary);">render()</code>, except <code class="font-mono" style="color: var(--color-primary);">variant</code> is ignored — all variants are always rendered.</p>
+      <p class="text-sm mb-4 text-body">Accepts the same options as <InlineCode>render()</InlineCode>, except <InlineCode>variant</InlineCode> is ignored — all variants are always rendered.</p>
     </section>
 
     <!-- close() -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">close()</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Shut down the browser process. Call this when you are done rendering to free resources.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">close()</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Shut down the browser process. Call this when you are done rendering to free resources.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="overflow-x-auto [&_pre]:px-4 [&_pre]:py-3 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-          <Code code={closeCallCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" code={closeCallCode} showCopy={false} class="mb-6" />
 
-      <div class="rounded-xl p-4 border-l-4 mb-8" style="background: rgba(251,146,60,0.08); border-left-color: var(--color-accent-amber);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-amber);">Caution: </span>
-          Always call <code class="font-mono">close()</code> when finished. Leaving the browser process running will leak memory and prevent your Node.js process from exiting cleanly.
-        </p>
-      </div>
+      <Callout type="amber" label="Caution:" class="mb-8">
+          Always call <InlineCode>close()</InlineCode> when finished. Leaving the browser process running will leak memory and prevent your Node.js process from exiting cleanly.
+      </Callout>
 
-      <h3 class="font-heading font-semibold text-lg mb-4" style="color: var(--color-text-primary);">Example — render multiple compositions</h3>
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={`import { render, close } from 'grafex';\nimport { writeFileSync } from 'node:fs';\n\nconst pages = [\n  { file: 'hero.tsx', out: 'hero.png' },\n  { file: 'card.tsx', out: 'card.png' },\n  { file: 'thumbnail.tsx', out: 'thumbnail.png' },\n];\n\nfor (const page of pages) {\n  const result = await render(page.file);\n  writeFileSync(page.out, result.buffer);\n}\n\nawait close();`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={renderMultipleCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <h3 class="font-heading font-semibold text-lg mb-4 text-heading">Example — render multiple compositions</h3>
+      <CodeBlock lang="typescript" code={renderMultipleCode} />
     </section>
 
     <!-- Advanced Exports -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Advanced Exports</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">For lower-level control, Grafex exposes additional internals:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Advanced Exports</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">For lower-level control, Grafex exposes additional internals:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text="import { h, Fragment, renderToHTML, BrowserManager } from 'grafex';" client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:px-4 [&_pre]:py-3 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-          <Code code={advancedImportCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" code={advancedImportCode} class="mb-6" />
 
-      <div class="rounded-xl overflow-hidden border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <div class="rounded-xl overflow-hidden border bg-surface border-edge">
         <table class="w-full text-sm">
           <thead>
-            <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-              <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Export</th>
-              <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+            <tr class="bg-surface-hover border-b border-edge">
+              <th class="text-left px-4 py-3 font-semibold text-heading">Export</th>
+              <th class="text-left px-4 py-3 font-semibold text-heading">Description</th>
             </tr>
           </thead>
           <tbody>
@@ -266,9 +207,9 @@ const closeCallCode = `await close();`;
               ['renderToHTML', 'Convert a composition to an HTML string without rendering to an image'],
               ['BrowserManager', 'Direct access to the browser lifecycle for custom workflows'],
             ].map(([name, desc]) => (
-              <tr style="border-bottom: 1px solid var(--color-border-default);">
-                <td class="px-4 py-3"><code class="font-mono text-sm" style="color: var(--color-primary);">{name}</code></td>
-                <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">{desc}</td>
+              <tr class="border-b border-edge">
+                <td class="px-4 py-3"><code class="font-mono text-sm text-pink">{name}</code></td>
+                <td class="px-4 py-3 text-sm text-body">{desc}</td>
               </tr>
             ))}
           </tbody>
@@ -278,59 +219,27 @@ const closeCallCode = `await close();`;
 
     <!-- Types -->
     <section>
-      <h2 class="font-heading font-bold text-2xl mb-6" style="color: var(--color-text-primary);">Types</h2>
+      <h2 class="font-heading font-bold text-2xl mb-6 text-heading">Types</h2>
 
       <div class="space-y-6">
         <div>
-          <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">VariantConfig</h3>
-          <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-            <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-              <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-              <CopyButton text={variantConfigTypeCode} client:load />
-            </div>
-            <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-              <Code code={variantConfigTypeCode} lang="typescript" theme={grafexTheme} />
-            </div>
-          </div>
+          <h3 class="font-heading font-semibold text-lg mb-3 text-heading">VariantConfig</h3>
+          <CodeBlock lang="typescript" code={variantConfigTypeCode} />
         </div>
 
         <div>
-          <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">CompositionConfig</h3>
-          <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-            <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-              <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-              <CopyButton text={compositionConfigTypeCode} client:load />
-            </div>
-            <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-              <Code code={compositionConfigTypeCode} lang="typescript" theme={grafexTheme} />
-            </div>
-          </div>
+          <h3 class="font-heading font-semibold text-lg mb-3 text-heading">CompositionConfig</h3>
+          <CodeBlock lang="typescript" code={compositionConfigTypeCode} />
         </div>
 
         <div>
-          <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">RenderResult</h3>
-          <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-            <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-              <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-              <CopyButton text={`interface RenderResult {\n  buffer: Buffer;          // Image data\n  width: number;           // Effective render width (after scaling)\n  height: number;          // Effective render height (after scaling)\n  format: 'png' | 'jpeg';  // Output format\n  scale: number;           // Device pixel ratio used\n}`} client:load />
-            </div>
-            <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-              <Code code={renderResultFullTypeCode} lang="typescript" theme={grafexTheme} />
-            </div>
-          </div>
+          <h3 class="font-heading font-semibold text-lg mb-3 text-heading">RenderResult</h3>
+          <CodeBlock lang="typescript" code={renderResultFullTypeCode} />
         </div>
 
         <div>
-          <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">RenderOptions</h3>
-          <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-            <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-              <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-              <CopyButton text={`interface RenderOptions {\n  props?: Record<string, unknown>;    // Props passed to the composition\n  width?: number;                     // Override width in pixels\n  height?: number;                    // Override height in pixels\n  format?: 'png' | 'jpeg';            // Output format (default: 'png')\n  quality?: number;                   // JPEG quality 1-100 (default: 90)\n  browser?: 'webkit' | 'chromium';    // Browser engine (default: 'webkit')\n  scale?: number;                     // Device pixel ratio (default: 1)\n  variant?: string;                   // Named variant to render\n}`} client:load />
-            </div>
-            <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-              <Code code={renderOptionsTypeCode} lang="typescript" theme={grafexTheme} />
-            </div>
-          </div>
+          <h3 class="font-heading font-semibold text-lg mb-3 text-heading">RenderOptions</h3>
+          <CodeBlock lang="typescript" code={renderOptionsTypeCode} />
         </div>
       </div>
     </section>

--- a/website/src/pages/docs/browser-setup.astro
+++ b/website/src/pages/docs/browser-setup.astro
@@ -1,15 +1,11 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import InlineCode from '../../components/InlineCode.astro';
+import Callout from '../../components/Callout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const autoInstallCode = `npm install grafex
 # WebKit is downloaded automatically`;
-
-const chromiumInstallCode = `npx playwright install chromium`;
-
-const chromiumCliCode = `grafex export -f card.tsx -o card.png --browser chromium`;
 
 const chromiumApiCode = `const result = await render('./card.tsx', {
   browser: 'chromium',
@@ -48,187 +44,105 @@ const githubActionsCode = `steps:
   currentPage="/docs/browser-setup"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">Browser Setup</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">Grafex renders compositions using a headless WebKit browser powered by Playwright. Most of the time, this is handled for you automatically.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">Browser Setup</h1>
+    <p class="text-lg mb-12 text-body">Grafex renders compositions using a headless WebKit browser powered by Playwright. Most of the time, this is handled for you automatically.</p>
 
     <!-- Automatic Installation -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Automatic Installation</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">When you run <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">npm install grafex</code>, a postinstall script downloads the WebKit binary. No action needed.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Automatic Installation</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">When you run <InlineCode>npm install grafex</InlineCode>, a postinstall script downloads the WebKit binary. No action needed.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npm install grafex" client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={autoInstallCode} lang="bash" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="bash" code={autoInstallCode} />
 
-      <p class="text-sm" style="color: var(--color-text-secondary);">The binary is cached — subsequent installs skip the download.</p>
+      <p class="text-sm text-body">The binary is cached — subsequent installs skip the download.</p>
     </section>
 
     <!-- Manual Installation -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Manual Installation</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">If the postinstall script fails (corporate proxies, restricted environments), install WebKit manually:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Manual Installation</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">If the postinstall script fails (corporate proxies, restricted environments), install WebKit manually:</p>
 
       <div class="space-y-4">
-        <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-          <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-            <CopyButton text="npx playwright install webkit" client:load />
-          </div>
-          <div class="px-4 py-3" style="background: var(--color-bg-code);">
-            <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx playwright install webkit</code>
-          </div>
-        </div>
+        <CodeBlock lang="bash" code="npx playwright install webkit" class="mb-0" />
 
-        <p class="text-sm" style="color: var(--color-text-secondary);">Or install only the browser binary without system dependencies:</p>
+        <p class="text-sm text-body">Or install only the browser binary without system dependencies:</p>
 
-        <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-          <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-            <CopyButton text="npx playwright-core install webkit" client:load />
-          </div>
-          <div class="px-4 py-3" style="background: var(--color-bg-code);">
-            <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx playwright-core install webkit</code>
-          </div>
-        </div>
+        <CodeBlock lang="bash" code="npx playwright-core install webkit" class="mb-0" />
       </div>
     </section>
 
     <!-- Chromium (Alternative Engine) -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Chromium (Alternative Engine)</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Grafex uses WebKit by default. Chromium is also supported if you hit CSS compatibility issues or need Chromium-specific rendering behavior. It requires a separate install:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Chromium (Alternative Engine)</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Grafex uses WebKit by default. Chromium is also supported if you hit CSS compatibility issues or need Chromium-specific rendering behavior. It requires a separate install:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npx playwright install chromium" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx playwright install chromium</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npx playwright install chromium" class="mb-6" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Then pass <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">--browser chromium</code> to the CLI:</p>
+      <p class="text-base leading-relaxed mb-4 text-body">Then pass <InlineCode>--browser chromium</InlineCode> to the CLI:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="grafex export -f card.tsx -o card.png --browser chromium" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex export -f card.tsx -o card.png --browser chromium</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="grafex export -f card.tsx -o card.png --browser chromium" class="mb-6" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Or set <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">browser: 'chromium'</code> in the library API:</p>
+      <p class="text-base leading-relaxed mb-4 text-body">Or set <InlineCode>browser: 'chromium'</InlineCode> in the library API:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">node</span>
-          <CopyButton text={`const result = await render('./card.tsx', {\n  browser: 'chromium',\n});`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={chromiumApiCode} lang="ts" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="typescript" label="node" code={chromiumApiCode} class="mb-6" />
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(56,189,248,0.08); border-left-color: var(--color-secondary);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-secondary);">Note: </span>
+      <Callout type="sky" label="Note:">
           WebKit is recommended for most use cases — it is smaller (~2 MB vs ~200 MB for Chromium) and downloaded automatically. Use Chromium only if you need specific rendering behavior that differs between engines.
-        </p>
-      </div>
+      </Callout>
     </section>
 
     <!-- PLAYWRIGHT_BROWSERS_PATH -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">PLAYWRIGHT_BROWSERS_PATH</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">By default, Playwright stores browser binaries in a shared cache directory under your home folder. Set <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">PLAYWRIGHT_BROWSERS_PATH</code> to change this location:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading"><code class="font-mono">PLAYWRIGHT_BROWSERS_PATH</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">By default, Playwright stores browser binaries in a shared cache directory under your home folder. Set <InlineCode>PLAYWRIGHT_BROWSERS_PATH</InlineCode> to change this location:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="export PLAYWRIGHT_BROWSERS_PATH=/path/to/browsers\nnpx playwright install webkit\ngrafex export -f card.tsx -o card.png" client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={playwrightBrowsersPathCode} lang="bash" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="bash" code={playwrightBrowsersPathCode} />
 
-      <p class="text-sm" style="color: var(--color-text-secondary);">This is useful in CI environments where the home directory is read-only or ephemeral.</p>
+      <p class="text-sm text-body">This is useful in CI environments where the home directory is read-only or ephemeral.</p>
     </section>
 
     <!-- CI Setup -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">CI Setup</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">On Linux, WebKit requires system-level dependencies (GTK, GStreamer, etc.). Install them before the browser binary:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">CI Setup</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">On Linux, WebKit requires system-level dependencies (GTK, GStreamer, etc.). Install them before the browser binary:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npx playwright install-deps webkit\nnpx playwright install webkit" client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={ciSetupCode} lang="bash" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="bash" code={ciSetupCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">GitHub Actions</h3>
+      <h3 class="font-heading font-semibold text-xl mb-4 text-heading">GitHub Actions</h3>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">.github/workflows/images.yml</span>
-          <CopyButton text={`steps:\n  - uses: actions/checkout@v4\n\n  - uses: actions/setup-node@v4\n    with:\n      node-version: 20\n\n  - name: Install dependencies\n    run: npm ci\n\n  - name: Install WebKit system dependencies\n    run: npx playwright install-deps webkit\n\n  - name: Install WebKit\n    run: npx playwright install webkit\n\n  - name: Export image\n    run: npx grafex export -f card.tsx -o card.png`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={githubActionsCode} lang="yaml" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="yaml" label=".github/workflows/images.yml" code={githubActionsCode} class="mb-6" />
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(56,189,248,0.08); border-left-color: var(--color-secondary);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-secondary);">Info: </span>
-          This pattern works in any CI environment that supports Node.js 20+. Adjust the dependency installation step for your platform (e.g., <code class="font-mono">apt-get</code> on Debian, <code class="font-mono">yum</code> on CentOS).
-        </p>
-      </div>
+      <Callout type="sky" label="Info:">
+          This pattern works in any CI environment that supports Node.js 20+. Adjust the dependency installation step for your platform (e.g., <InlineCode>apt-get</InlineCode> on Debian, <InlineCode>yum</InlineCode> on CentOS).
+      </Callout>
     </section>
 
     <!-- Troubleshooting -->
     <section>
-      <h2 class="font-heading font-bold text-2xl mb-6" style="color: var(--color-text-primary);">Troubleshooting</h2>
+      <h2 class="font-heading font-bold text-2xl mb-6 text-heading">Troubleshooting</h2>
 
       <div class="space-y-6">
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="font-semibold mb-2" style="color: var(--color-text-primary);">"Browser not found" error</p>
-          <p class="text-sm mb-3" style="color: var(--color-text-secondary);">WebKit was not downloaded. Run:</p>
-          <div class="rounded-lg px-4 py-2 font-mono text-sm" style="background: var(--color-bg-code); color: var(--color-accent-lime);">
-            npx playwright install webkit
-          </div>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="font-semibold mb-2 text-heading">"Browser not found" error</p>
+          <p class="text-sm mb-3 text-body">WebKit was not downloaded. Run:</p>
+          <CodeBlock lang="bash" code="npx playwright install webkit" showCopy={false} class="mb-0" />
         </div>
 
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="font-semibold mb-2" style="color: var(--color-text-primary);">"Missing system dependencies" error (Linux)</p>
-          <p class="text-sm mb-3" style="color: var(--color-text-secondary);">WebKit needs system libraries that are not installed. Run:</p>
-          <div class="rounded-lg px-4 py-2 font-mono text-sm" style="background: var(--color-bg-code); color: var(--color-accent-lime);">
-            npx playwright install-deps webkit
-          </div>
-          <p class="text-sm mt-3" style="color: var(--color-text-secondary);">Then retry your export.</p>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="font-semibold mb-2 text-heading">"Missing system dependencies" error (Linux)</p>
+          <p class="text-sm mb-3 text-body">WebKit needs system libraries that are not installed. Run:</p>
+          <CodeBlock lang="bash" code="npx playwright install-deps webkit" showCopy={false} class="mb-0" />
+          <p class="text-sm mt-3 text-body">Then retry your export.</p>
         </div>
 
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="font-semibold mb-2" style="color: var(--color-text-primary);">Slow first render</p>
-          <p class="text-sm" style="color: var(--color-text-secondary);">The first render takes longer because Grafex launches a new WebKit instance. Subsequent renders reuse the browser and are significantly faster (5-50ms). If you are rendering multiple images, use the library API to batch them with a single <code class="font-mono">render()</code> loop and one <code class="font-mono">close()</code> at the end.</p>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="font-semibold mb-2 text-heading">Slow first render</p>
+          <p class="text-sm text-body">The first render takes longer because Grafex launches a new WebKit instance. Subsequent renders reuse the browser and are significantly faster (5-50ms). If you are rendering multiple images, use the library API to batch them with a single <InlineCode>render()</InlineCode> loop and one <InlineCode>close()</InlineCode> at the end.</p>
         </div>
 
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="font-semibold mb-2" style="color: var(--color-text-primary);">Disk space concerns</p>
-          <p class="text-sm" style="color: var(--color-text-secondary);">The WebKit binary is approximately 2 MB (compressed). It is cached after the first download. Compare this to Puppeteer's Chromium at 200 MB+.</p>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="font-semibold mb-2 text-heading">Disk space concerns</p>
+          <p class="text-sm text-body">The WebKit binary is approximately 2 MB (compressed). It is cached after the first download. Compare this to Puppeteer's Chromium at 200 MB+.</p>
         </div>
       </div>
     </section>

--- a/website/src/pages/docs/cli.astro
+++ b/website/src/pages/docs/cli.astro
@@ -1,8 +1,7 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import InlineCode from '../../components/InlineCode.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const globalFlagsCode = `grafex --version    # Print version and exit
 grafex --help       # Print help text and exit`;
@@ -14,49 +13,41 @@ grafex --help       # Print help text and exit`;
   currentPage="/docs/cli"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">CLI Reference</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">Complete reference for all CLI commands and flags.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">CLI Reference</h1>
+    <p class="text-lg mb-12 text-body">Complete reference for all CLI commands and flags.</p>
 
     <!-- grafex init -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">grafex init</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Scaffold the minimal setup to start writing compositions. Run this in a new project after <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">npm install grafex</code>.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">grafex init</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Scaffold the minimal setup to start writing compositions. Run this in a new project after <InlineCode>npm install grafex</InlineCode>.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="grafex init" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex init</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="grafex init" class="mb-6" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Creates two files in the current directory:</p>
-      <ul class="list-disc list-inside space-y-2 text-base mb-6" style="color: var(--color-text-secondary);">
-        <li><code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">tsconfig.json</code> — TypeScript config with the correct JSX settings for Grafex</li>
-        <li><code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">composition.tsx</code> — A starter composition with a "Hello, Grafex!" example</li>
+      <p class="text-base leading-relaxed mb-4 text-body">Creates two files in the current directory:</p>
+      <ul class="list-disc list-inside space-y-2 text-base mb-6 text-body">
+        <li><InlineCode>tsconfig.json</InlineCode> — TypeScript config with the correct JSX settings for Grafex</li>
+        <li><InlineCode>composition.tsx</InlineCode> — A starter composition with a "Hello, Grafex!" example</li>
       </ul>
 
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">If either file already exists, it is skipped without error.</p>
+      <p class="text-base leading-relaxed mb-6 text-body">If either file already exists, it is skipped without error.</p>
 
-      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">Flags</h3>
+      <h3 class="font-heading font-semibold text-xl mb-4 text-heading">Flags</h3>
 
-      <div class="rounded-xl overflow-hidden border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <div class="rounded-xl overflow-hidden border bg-surface border-edge">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Flag</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Short</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+              <tr class="bg-surface-hover border-b border-edge">
+                <th class="text-left px-4 py-3 font-semibold text-heading">Flag</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Short</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Description</th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-primary);">--help</code></td>
-                <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-secondary);">-h</code></td>
-                <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">Show help text</td>
+                <td class="px-4 py-3"><code class="font-mono text-sm text-pink">--help</code></td>
+                <td class="px-4 py-3"><code class="font-mono text-sm text-sky">-h</code></td>
+                <td class="px-4 py-3 text-sm text-body">Show help text</td>
               </tr>
             </tbody>
           </table>
@@ -66,31 +57,23 @@ grafex --help       # Print help text and exit`;
 
     <!-- grafex export -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">grafex export</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Render a composition file to an image.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">grafex export</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Render a composition file to an image.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-8" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="grafex export -f <file> [options]" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex export -f &lt;file&gt; [options]</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="grafex export -f <file> [options]" class="mb-8" />
 
-      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">Flags</h3>
+      <h3 class="font-heading font-semibold text-xl mb-4 text-heading">Flags</h3>
 
-      <div class="rounded-xl overflow-hidden border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <div class="rounded-xl overflow-hidden border bg-surface border-edge">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Flag</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Short</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Type</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Default</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+              <tr class="bg-surface-hover border-b border-edge">
+                <th class="text-left px-4 py-3 font-semibold text-heading">Flag</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Short</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Type</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Default</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Description</th>
               </tr>
             </thead>
             <tbody>
@@ -107,12 +90,12 @@ grafex --help       # Print help text and exit`;
                 ['--variant', '', 'string', '(all)', 'Render a single variant by name. Omit to render all variants.'],
                 ['--help', '-h', '', '', 'Show help text'],
               ].map(([flag, short, type, def, desc]) => (
-                <tr style="border-bottom: 1px solid var(--color-border-default);">
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-primary);">{flag}</code></td>
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: short ? 'var(--color-secondary)' : 'var(--color-text-muted)'">{short || '—'}</code></td>
-                  <td class="px-4 py-3 text-xs" style="color: var(--color-text-muted);">{type || '—'}</td>
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-accent-lime);">{def}</code></td>
-                  <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">{desc}</td>
+                <tr class="border-b border-edge">
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-pink">{flag}</code></td>
+                  <td class="px-4 py-3"><code class={`font-mono text-sm ${short ? "text-sky" : "text-muted"}`}>{short || "—"}</code></td>
+                  <td class="px-4 py-3 text-xs text-muted">{type || '—'}</td>
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-lime">{def}</code></td>
+                  <td class="px-4 py-3 text-sm text-body">{desc}</td>
                 </tr>
               ))}
             </tbody>
@@ -123,7 +106,7 @@ grafex --help       # Print help text and exit`;
 
     <!-- Examples -->
     <section class="mb-12">
-      <h3 class="font-heading font-semibold text-xl mb-6" style="color: var(--color-text-primary);">Examples</h3>
+      <h3 class="font-heading font-semibold text-xl mb-6 text-heading">Examples</h3>
 
       <div class="space-y-4">
         {[
@@ -139,16 +122,8 @@ grafex --help       # Print help text and exit`;
           { label: 'Export a single variant', cmd: 'grafex export -f card.tsx --variant twitter -o twitter.png' },
         ].map((ex) => (
           <div>
-            <p class="text-sm mb-2 font-medium" style="color: var(--color-text-secondary);">{ex.label}:</p>
-            <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-              <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-                <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-                <CopyButton text={ex.cmd} client:load />
-              </div>
-              <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-                <code class="font-mono text-sm whitespace-nowrap" style="color: var(--color-accent-lime);">{ex.cmd}</code>
-              </div>
-            </div>
+            <p class="text-sm mb-2 font-medium text-body">{ex.label}:</p>
+            <CodeBlock lang="bash" code={ex.cmd} />
           </div>
         ))}
       </div>
@@ -156,23 +131,23 @@ grafex --help       # Print help text and exit`;
 
     <!-- Exit codes -->
     <section class="mb-12">
-      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">Exit codes</h3>
-      <div class="rounded-xl overflow-hidden border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <h3 class="font-heading font-semibold text-xl mb-4 text-heading">Exit codes</h3>
+      <div class="rounded-xl overflow-hidden border bg-surface border-edge">
         <table class="w-full text-sm">
           <thead>
-            <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-              <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Code</th>
-              <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Meaning</th>
+            <tr class="bg-surface-hover border-b border-edge">
+              <th class="text-left px-4 py-3 font-semibold text-heading">Code</th>
+              <th class="text-left px-4 py-3 font-semibold text-heading">Meaning</th>
             </tr>
           </thead>
           <tbody>
-            <tr style="border-bottom: 1px solid var(--color-border-default);">
-              <td class="px-4 py-3"><code class="font-mono text-sm" style="color: var(--color-accent-lime);">0</code></td>
-              <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">Success — image exported</td>
+            <tr class="border-b border-edge">
+              <td class="px-4 py-3"><code class="font-mono text-sm text-pink">0</code></td>
+              <td class="px-4 py-3 text-sm text-body">Success — image exported</td>
             </tr>
             <tr>
-              <td class="px-4 py-3"><code class="font-mono text-sm" style="color: var(--color-error);">1</code></td>
-              <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">Error — composition failed to render (check stderr for details)</td>
+              <td class="px-4 py-3"><code class="font-mono text-sm text-pink">1</code></td>
+              <td class="px-4 py-3 text-sm text-body">Error — composition failed to render (check stderr for details)</td>
             </tr>
           </tbody>
         </table>
@@ -181,31 +156,23 @@ grafex --help       # Print help text and exit`;
 
     <!-- grafex dev -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-2" style="color: var(--color-text-primary);"><code class="font-mono" style="color: var(--color-primary);">grafex dev</code></h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Start a live preview server that watches your composition and re-renders on every file change.</p>
+      <h2 class="font-heading font-bold text-2xl mb-2 text-heading"><code class="font-mono">grafex dev</code></h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Start a live preview server that watches your composition and re-renders on every file change.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-8" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="grafex dev -f <file> [options]" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex dev -f &lt;file&gt; [options]</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="grafex dev -f <file> [options]" class="mb-8" />
 
-      <h3 class="font-heading font-semibold text-xl mb-4" style="color: var(--color-text-primary);">Flags</h3>
+      <h3 class="font-heading font-semibold text-xl mb-4 text-heading">Flags</h3>
 
-      <div class="rounded-xl overflow-hidden border mb-8" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
+      <div class="rounded-xl overflow-hidden border mb-8 bg-surface border-edge">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr style="background: var(--color-bg-surface-hover); border-bottom: 1px solid var(--color-border-default);">
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Flag</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Short</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Type</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Default</th>
-                <th class="text-left px-4 py-3 font-semibold" style="color: var(--color-text-primary);">Description</th>
+              <tr class="bg-surface-hover border-b border-edge">
+                <th class="text-left px-4 py-3 font-semibold text-heading">Flag</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Short</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Type</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Default</th>
+                <th class="text-left px-4 py-3 font-semibold text-heading">Description</th>
               </tr>
             </thead>
             <tbody>
@@ -216,12 +183,12 @@ grafex --help       # Print help text and exit`;
                 ['--variant', '', 'string', '(first)', 'Show only the named variant (when composition has variants)'],
                 ['--help', '-h', '', '', 'Show help text'],
               ].map(([flag, short, type, def, desc]) => (
-                <tr style="border-bottom: 1px solid var(--color-border-default);">
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-primary);">{flag}</code></td>
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: short ? 'var(--color-secondary)' : 'var(--color-text-muted)'">{short || '—'}</code></td>
-                  <td class="px-4 py-3 text-xs" style="color: var(--color-text-muted);">{type || '—'}</td>
-                  <td class="px-4 py-3"><code class="font-mono text-xs" style="color: var(--color-accent-lime);">{def}</code></td>
-                  <td class="px-4 py-3 text-sm" style="color: var(--color-text-secondary);">{desc}</td>
+                <tr class="border-b border-edge">
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-pink">{flag}</code></td>
+                  <td class="px-4 py-3"><code class={`font-mono text-sm ${short ? "text-sky" : "text-muted"}`}>{short || "—"}</code></td>
+                  <td class="px-4 py-3 text-xs text-muted">{type || '—'}</td>
+                  <td class="px-4 py-3"><code class="font-mono text-sm text-lime">{def}</code></td>
+                  <td class="px-4 py-3 text-sm text-body">{desc}</td>
                 </tr>
               ))}
             </tbody>
@@ -229,22 +196,15 @@ grafex --help       # Print help text and exit`;
         </div>
       </div>
 
-      <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">
-        The dev server watches the composition file, all its imports, CSS files from <code class="font-mono text-xs" style="color: var(--color-primary);">config.css</code>, and local image assets. Changes are debounced and the preview updates within ~100ms. Open <code class="font-mono text-xs" style="color: var(--color-primary);">http://localhost:3000</code> to see the live preview. Press <kbd style="background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: 4px; padding: 1px 5px; font-size: 11px;">Ctrl+C</kbd> to stop.
+      <p class="text-sm leading-relaxed text-body">
+        The dev server watches the composition file, all its imports, CSS files from <InlineCode>config.css</InlineCode>, and local image assets. Changes are debounced and the preview updates within ~100ms. Open <InlineCode>http://localhost:3000</InlineCode> to see the live preview. Press <kbd class="bg-surface border border-edge rounded px-1 text-[11px]">Ctrl+C</kbd> to stop.
       </p>
     </section>
 
     <!-- Global Flags -->
     <section>
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Global Flags</h2>
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={globalFlagsCode} lang="bash" theme={grafexTheme} />
-        </div>
-      </div>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Global Flags</h2>
+      <CodeBlock lang="bash" code={globalFlagsCode} showCopy={false} />
     </section>
   </article>
 </DocsLayout>

--- a/website/src/pages/docs/compositions.astro
+++ b/website/src/pages/docs/compositions.astro
@@ -1,8 +1,8 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import InlineCode from '../../components/InlineCode.astro';
+import Callout from '../../components/Callout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const overviewCode = `import type { CompositionConfig } from 'grafex';
 
@@ -72,6 +72,8 @@ export default function BlogCard({ title, date }: Props) {
     </div>
   );
 }`;
+
+const propsExportCmd = `grafex export -f blog-card.tsx -o card.png --props '{"title":"My Post","date":"March 2026"}'`;
 
 const ogCardFullCode = `export const config = {
   width: 600,
@@ -283,6 +285,38 @@ for (const [name, result] of all) {
 }
 
 await close();`;
+
+const cssFilesCode = `import type { CompositionConfig } from 'grafex';
+
+export const config: CompositionConfig = {
+  width: 1200,
+  height: 630,
+  css: ['./styles.css'],
+};
+
+export default function Card() {
+  return (
+    <div className="card">
+      <h1 className="title">Hello</h1>
+    </div>
+  );
+}`;
+
+const tailwindCssCode = `import type { CompositionConfig } from 'grafex';
+
+export const config: CompositionConfig = {
+  width: 1200,
+  height: 630,
+  css: ['./styles.css'],
+};
+
+export default function Card() {
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white">
+      <h1 className="text-6xl font-bold">Hello Tailwind</h1>
+    </div>
+  );
+}`;
 ---
 
 <DocsLayout
@@ -291,51 +325,43 @@ await close();`;
   currentPage="/docs/compositions"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">Compositions</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">Compositions are TSX files that describe your image layout. They use a custom JSX runtime — not React — so there are no hooks, no state, and no effects. Just pure functions that return markup.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">Compositions</h1>
+    <p class="text-lg mb-12 text-body">Compositions are TSX files that describe your image layout. They use a custom JSX runtime — not React — so there are no hooks, no state, and no effects. Just pure functions that return markup.</p>
 
     <!-- Overview -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Overview</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Every composition exports two things:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Overview</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Every composition exports two things:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">example.tsx</span>
-          <CopyButton text={overviewCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={overviewCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
-      <p class="text-sm" style="color: var(--color-text-secondary);">The config is optional. If omitted, Grafex defaults to 1200×630.</p>
+      <CodeBlock lang="tsx" label="example.tsx" code={overviewCode} />
+      <p class="text-sm text-body">The config is optional. If omitted, Grafex defaults to 1200×630.</p>
     </section>
 
     <!-- JSX Runtime -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">The JSX Runtime</h2>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Grafex provides its own <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">h()</code> and <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">Fragment</code> functions. You do not need to import React or configure a JSX pragma — Grafex handles the transform automatically via esbuild.
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">The JSX Runtime</h2>
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Grafex provides its own <InlineCode>h()</InlineCode> and <InlineCode>Fragment</InlineCode> functions. You do not need to import React or configure a JSX pragma — Grafex handles the transform automatically via esbuild.
       </p>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Your components are called once to produce HTML. There is no virtual DOM, no reconciliation, no component lifecycle. Think of compositions as template functions, not interactive components.</p>
+      <p class="text-base leading-relaxed mb-6 text-body">Your components are called once to produce HTML. There is no virtual DOM, no reconciliation, no component lifecycle. Think of compositions as template functions, not interactive components.</p>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="text-sm font-semibold mb-3" style="color: var(--color-accent-lime);">What works</p>
-          <ul class="space-y-1.5 text-sm" style="color: var(--color-text-secondary);">
-            <li>HTML elements (<code class="font-mono" style="color: var(--color-primary);">div</code>, <code class="font-mono" style="color: var(--color-primary);">span</code>, <code class="font-mono" style="color: var(--color-primary);">img</code>, <code class="font-mono" style="color: var(--color-primary);">svg</code>)</li>
-            <li>Inline styles via <code class="font-mono" style="color: var(--color-primary);">style</code> prop</li>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="text-sm font-semibold mb-3 text-lime">What works</p>
+          <ul class="space-y-1.5 text-sm text-body">
+            <li>HTML elements (<InlineCode>div</InlineCode>, <InlineCode>span</InlineCode>, <InlineCode>img</InlineCode>, <InlineCode>svg</InlineCode>)</li>
+            <li>Inline styles via <InlineCode>style</InlineCode> prop</li>
             <li>Children, nesting, and composition</li>
             <li>Conditional rendering</li>
             <li>Array mapping</li>
-            <li>Fragment syntax (<code class="font-mono" style="color: var(--color-primary);">&lt;&gt;...&lt;/&gt;</code>)</li>
+            <li>Fragment syntax (<InlineCode>&lt;&gt;...&lt;/&gt;</InlineCode>)</li>
           </ul>
         </div>
-        <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <p class="text-sm font-semibold mb-3" style="color: var(--color-text-muted);">Does not apply</p>
-          <ul class="space-y-1.5 text-sm" style="color: var(--color-text-secondary);">
-            <li><code class="font-mono" style="color: var(--color-text-muted);">useState</code>, <code class="font-mono" style="color: var(--color-text-muted);">useEffect</code>, or any hooks</li>
-            <li>Event handlers (<code class="font-mono" style="color: var(--color-text-muted);">onClick</code>, etc.)</li>
+        <div class="rounded-xl p-5 border bg-surface border-edge">
+          <p class="text-sm font-semibold mb-3 text-muted">Does not apply</p>
+          <ul class="space-y-1.5 text-sm text-body">
+            <li><InlineCode>useState</InlineCode>, <InlineCode>useEffect</InlineCode>, or any hooks</li>
+            <li>Event handlers (<InlineCode>onClick</InlineCode>, etc.)</li>
             <li>Client-side interactivity</li>
           </ul>
         </div>
@@ -344,247 +370,116 @@ await close();`;
 
     <!-- CompositionConfig -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">CompositionConfig</h2>
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={compositionConfigCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={compositionConfigCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
-      <p class="text-sm mb-4" style="color: var(--color-text-secondary);">Dimensions can also be overridden at export time via CLI flags (<code class="font-mono" style="color: var(--color-primary);">--width</code>, <code class="font-mono" style="color: var(--color-primary);">--height</code>) or API options. CLI/API values take precedence over the config export.</p>
-      <p class="text-sm" style="color: var(--color-text-secondary);"><code class="font-mono" style="color: var(--color-primary);">scale</code> sets the device pixel ratio for rendering. The default is <code class="font-mono" style="color: var(--color-accent-lime);">1</code>. Set it to <code class="font-mono" style="color: var(--color-accent-lime);">2</code> for retina-quality output — the layout stays the same, but the image is rendered at double the pixel density. A 1200x630 composition at <code class="font-mono" style="color: var(--color-accent-lime);">scale: 2</code> outputs a 2400x1260 PNG. Accepts any positive number, including decimals like <code class="font-mono" style="color: var(--color-accent-lime);">1.5</code> or <code class="font-mono" style="color: var(--color-accent-lime);">0.5</code>. Like <code class="font-mono" style="color: var(--color-primary);">width</code> and <code class="font-mono" style="color: var(--color-primary);">height</code>, <code class="font-mono" style="color: var(--color-primary);">scale</code> can be overridden at export time via the <code class="font-mono" style="color: var(--color-primary);">--scale</code> CLI flag or the <code class="font-mono" style="color: var(--color-primary);">scale</code> option in the API.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">CompositionConfig</h2>
+      <CodeBlock lang="typescript" code={compositionConfigCode} />
+      <p class="text-sm mb-4 text-body">Dimensions can also be overridden at export time via CLI flags (<InlineCode>--width</InlineCode>, <InlineCode>--height</InlineCode>) or API options. CLI/API values take precedence over the config export.</p>
+      <p class="text-sm text-body"><InlineCode>scale</InlineCode> sets the device pixel ratio for rendering. The default is <InlineCode>1</InlineCode>. Set it to <InlineCode>2</InlineCode> for retina-quality output — the layout stays the same, but the image is rendered at double the pixel density. A 1200x630 composition at <InlineCode>scale: 2</InlineCode> outputs a 2400x1260 PNG. Accepts any positive number, including decimals like <InlineCode>1.5</InlineCode> or <InlineCode>0.5</InlineCode>. Like <InlineCode>width</InlineCode> and <InlineCode>height</InlineCode>, <InlineCode>scale</InlineCode> can be overridden at export time via the <InlineCode>--scale</InlineCode> CLI flag or the <InlineCode>scale</InlineCode> option in the API.</p>
     </section>
 
     <!-- Custom Fonts -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Custom Fonts</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Load external fonts by providing URLs in <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.fonts</code>. Grafex fetches each URL before rendering, so Google Fonts and any other CSS font URL work out of the box.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Custom Fonts</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Load external fonts by providing URLs in <InlineCode>config.fonts</InlineCode>. Grafex fetches each URL before rendering, so Google Fonts and any other CSS font URL work out of the box.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={customFontsCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={customFontsCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={customFontsCode} />
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
-          Any CSS font URL works — Google Fonts, Adobe Fonts, or a self-hosted stylesheet. Grafex injects each URL as a <code class="font-mono">&lt;link&gt;</code> element before rendering.
-        </p>
-      </div>
+      <Callout type="lime" label="Tip:">
+          Any CSS font URL works — Google Fonts, Adobe Fonts, or a self-hosted stylesheet. Grafex injects each URL as a <InlineCode>&lt;link&gt;</InlineCode> element before rendering.
+      </Callout>
     </section>
 
     <!-- CSS Files -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">CSS Files</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Load external CSS files by specifying paths in <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code>. Paths are resolved relative to the composition file. The CSS is injected as <code class="font-mono">&lt;style&gt;</code> tags in the HTML <code class="font-mono">&lt;head&gt;</code> before rendering.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">CSS Files</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Load external CSS files by specifying paths in <InlineCode>config.css</InlineCode>. Paths are resolved relative to the composition file. The CSS is injected as <InlineCode>&lt;style&gt;</InlineCode> tags in the HTML <InlineCode>&lt;head&gt;</InlineCode> before rendering.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={`import type { CompositionConfig } from 'grafex';\n\nexport const config: CompositionConfig = {\n  width: 1200,\n  height: 630,\n  css: ['./styles.css'],\n};\n\nexport default function Card() {\n  return (\n    <div className="card">\n      <h1 className="title">Hello</h1>\n    </div>\n  );\n}`} client:load />
-        </div>
-        <div class="p-4 overflow-x-auto" style="background: var(--color-bg-code); max-height: 500px; overflow-y: auto;">
-          <pre class="font-mono text-sm leading-relaxed"><code><span style="color:#F472B6">import</span><span style="color:#94A3B8"> type {"{"} </span><span style="color:#38BDF8">CompositionConfig</span><span style="color:#94A3B8"> {"}"} </span><span style="color:#F472B6">from</span><span style="color:#A3E635"> 'grafex'</span><span style="color:#94A3B8">;</span>
+      <CodeBlock lang="tsx" label="card.tsx" code={cssFilesCode} />
 
-<span style="color:#F472B6">export</span><span style="color:#F472B6"> const</span><span style="color:#38BDF8"> config</span><span style="color:#94A3B8">:</span><span style="color:#38BDF8"> CompositionConfig</span><span style="color:#94A3B8"> = {"{"}</span>
-<span style="color:#38BDF8">  width</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 1200</span><span style="color:#94A3B8">,</span>
-<span style="color:#38BDF8">  height</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 630</span><span style="color:#94A3B8">,</span>
-<span style="color:#38BDF8">  css</span><span style="color:#94A3B8">: [</span><span style="color:#A3E635">'./styles.css'</span><span style="color:#94A3B8">],</span>
-<span style="color:#94A3B8">{"}"};</span>
+      <Callout type="lime" label="Tip:" class="mb-6">
+          This is a generic file injection mechanism — it works with plain CSS, Tailwind output, Sass output, or any other <InlineCode>.css</InlineCode> file. Grafex doesn't care how the CSS was generated.
+      </Callout>
 
-<span style="color:#F472B6">export</span><span style="color:#F472B6"> default</span><span style="color:#F472B6"> function</span><span style="color:#38BDF8"> Card</span><span style="color:#94A3B8">() {"{"}</span>
-<span style="color:#F472B6">  return</span><span style="color:#94A3B8"> (</span>
-<span style="color:#F472B6">    &lt;div</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"card"</span><span style="color:#F472B6">&gt;</span>
-<span style="color:#F472B6">      &lt;h1</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"title"</span><span style="color:#F472B6">&gt;</span>Hello<span style="color:#F472B6">&lt;/h1&gt;</span>
-<span style="color:#F472B6">    &lt;/div&gt;</span>
-<span style="color:#94A3B8">  );</span>
-<span style="color:#94A3B8">{"}"}</span></code></pre>
-        </div>
-      </div>
-
-      <div class="rounded-xl p-4 border-l-4 mb-6" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
-          This is a generic file injection mechanism — it works with plain CSS, Tailwind output, Sass output, or any other <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">.css</code> file. Grafex doesn't care how the CSS was generated.
-        </p>
-      </div>
-
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">Tailwind CSS</h3>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Run Tailwind's CLI to compile your stylesheet, then reference the output in <code class="font-mono text-sm" style="color: var(--color-primary);">config.css</code>. In dev mode, Tailwind's <code class="font-mono text-sm">--watch</code> flag recompiles on every change, and Grafex detects the updated CSS file and re-renders automatically.
-        See the <a href="/docs/tailwind" class="transition-colors duration-150 text-[var(--color-primary)] hover:text-[var(--color-primary-hover)]">Tailwind CSS guide</a> for the full dev workflow, npm scripts, and a working example.
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">Tailwind CSS</h3>
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Run Tailwind's CLI to compile your stylesheet, then reference the output in <InlineCode>config.css</InlineCode>. In dev mode, Tailwind's <InlineCode>--watch</InlineCode> flag recompiles on every change, and Grafex detects the updated CSS file and re-renders automatically.
+        See the <a href="/docs/tailwind" class="transition-colors duration-150 text-pink hover:text-pink-hover">Tailwind CSS guide</a> for the full dev workflow, npm scripts, and a working example.
       </p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">terminal</span>
-        </div>
-        <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx tailwindcss -i ./input.css -o ./styles.css</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npx tailwindcss -i ./input.css -o ./styles.css" class="mb-6" />
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={`import type { CompositionConfig } from 'grafex';\n\nexport const config: CompositionConfig = {\n  width: 1200,\n  height: 630,\n  css: ['./styles.css'],\n};\n\nexport default function Card() {\n  return (\n    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white">\n      <h1 className="text-6xl font-bold">Hello Tailwind</h1>\n    </div>\n  );\n}`} client:load />
-        </div>
-        <div class="p-4 overflow-x-auto" style="background: var(--color-bg-code); max-height: 500px; overflow-y: auto;">
-          <pre class="font-mono text-sm leading-relaxed"><code><span style="color:#F472B6">import</span><span style="color:#94A3B8"> type {"{"} </span><span style="color:#38BDF8">CompositionConfig</span><span style="color:#94A3B8"> {"}"} </span><span style="color:#F472B6">from</span><span style="color:#A3E635"> 'grafex'</span><span style="color:#94A3B8">;</span>
-
-<span style="color:#F472B6">export</span><span style="color:#F472B6"> const</span><span style="color:#38BDF8"> config</span><span style="color:#94A3B8">:</span><span style="color:#38BDF8"> CompositionConfig</span><span style="color:#94A3B8"> = {"{"}</span>
-<span style="color:#38BDF8">  width</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 1200</span><span style="color:#94A3B8">,</span>
-<span style="color:#38BDF8">  height</span><span style="color:#94A3B8">:</span><span style="color:#FB923C"> 630</span><span style="color:#94A3B8">,</span>
-<span style="color:#38BDF8">  css</span><span style="color:#94A3B8">: [</span><span style="color:#A3E635">'./styles.css'</span><span style="color:#94A3B8">],</span>
-<span style="color:#94A3B8">{"}"};</span>
-
-<span style="color:#F472B6">export</span><span style="color:#F472B6"> default</span><span style="color:#F472B6"> function</span><span style="color:#38BDF8"> Card</span><span style="color:#94A3B8">() {"{"}</span>
-<span style="color:#F472B6">  return</span><span style="color:#94A3B8"> (</span>
-<span style="color:#F472B6">    &lt;div</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"w-full h-full flex items-center justify-center bg-gradient-to-br from-indigo-500 to-purple-600 text-white"</span><span style="color:#F472B6">&gt;</span>
-<span style="color:#F472B6">      &lt;h1</span><span style="color:#38BDF8"> className</span><span style="color:#94A3B8">=</span><span style="color:#A3E635">"text-6xl font-bold"</span><span style="color:#F472B6">&gt;</span>Hello Tailwind<span style="color:#F472B6">&lt;/h1&gt;</span>
-<span style="color:#F472B6">    &lt;/div&gt;</span>
-<span style="color:#94A3B8">  );</span>
-<span style="color:#94A3B8">{"}"}</span></code></pre>
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={tailwindCssCode} />
     </section>
 
     <!-- HTML Attributes -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">HTML Attributes</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Set arbitrary attributes on the root <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">&lt;html&gt;</code> element via <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.htmlAttributes</code>. This enables CSS selectors like <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">:root[data-theme="dark"]</code> used by Tailwind v4 themes and other theming systems.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">HTML Attributes</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Set arbitrary attributes on the root <InlineCode>&lt;html&gt;</InlineCode> element via <InlineCode>config.htmlAttributes</InlineCode>. This enables CSS selectors like <InlineCode>:root[data-theme="dark"]</InlineCode> used by Tailwind v4 themes and other theming systems.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={htmlAttributesCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={htmlAttributesCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={htmlAttributesCode} />
 
-      <p class="text-sm mb-4" style="color: var(--color-text-secondary);">This renders as <code class="font-mono" style="color: var(--color-primary);">&lt;html data-theme="dark" lang="en"&gt;</code>. Attribute values are HTML-escaped automatically.</p>
+      <p class="text-sm mb-4 text-body">This renders as <InlineCode>&lt;html data-theme="dark" lang="en"&gt;</InlineCode>. Attribute values are HTML-escaped automatically.</p>
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Variants: </span>
-          When a variant sets <code class="font-mono text-sm" style="color: var(--color-primary);">htmlAttributes</code>, its entries are spread over the base config's attributes. This means you can override individual keys per variant without repeating the rest.
-        </p>
-      </div>
+      <Callout type="lime" label="Variants:">
+          When a variant sets <InlineCode>htmlAttributes</InlineCode>, its entries are spread over the base config's attributes. This means you can override individual keys per variant without repeating the rest.
+      </Callout>
     </section>
 
     <!-- Local Images -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Images</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Use local image files in <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">&lt;img&gt;</code> tags or CSS <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">background-image</code>. Grafex reads them from disk and embeds them as base64 data URLs automatically — no server or public URL needed.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Images</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Use local image files in <InlineCode>&lt;img&gt;</InlineCode> tags or CSS <InlineCode>background-image</InlineCode>. Grafex reads them from disk and embeds them as base64 data URLs automatically — no server or public URL needed.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={localImageCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={localImageCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={localImageCode} />
 
-      <p class="text-sm mb-4" style="color: var(--color-text-secondary);">Paths are resolved relative to the composition file. Supported formats: PNG, JPEG, GIF, WebP, SVG, AVIF, ICO, BMP. Remote URLs (<code class="font-mono" style="color: var(--color-primary);">http://</code>, <code class="font-mono" style="color: var(--color-primary);">https://</code>) and data URLs are passed through unchanged.</p>
+      <p class="text-sm mb-4 text-body">Paths are resolved relative to the composition file. Supported formats: PNG, JPEG, GIF, WebP, SVG, AVIF, ICO, BMP. Remote URLs (<InlineCode>http://</InlineCode>, <InlineCode>https://</InlineCode>) and data URLs are passed through unchanged.</p>
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">CSS <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">url()</code> references work too — both in inline styles and in external CSS files loaded via <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code>:</p>
+      <p class="text-base leading-relaxed mb-4 text-body">CSS <InlineCode>url()</InlineCode> references work too — both in inline styles and in external CSS files loaded via <InlineCode>config.css</InlineCode>:</p>
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">styles.css</span>
-          <CopyButton text={cssUrlCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={cssUrlCode} lang="css" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="css" label="styles.css" code={cssUrlCode} />
     </section>
 
     <!-- Styling -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Styling</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Style compositions using the <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">style</code> prop with a CSS-in-JS object:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Styling</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Style compositions using the <InlineCode>style</InlineCode> prop with a CSS-in-JS object:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">example.tsx</span>
-          <CopyButton text={stylingCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={stylingCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="example.tsx" code={stylingCode} class="mb-6" />
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
-          Unlike Satori, Grafex supports the full CSS spec because it renders in a real browser engine. Flexbox, Grid, <code class="font-mono">calc()</code>, CSS variables, <code class="font-mono">z-index</code>, gradients, shadows, transforms — it all works.
-        </p>
-      </div>
+      <Callout type="lime" label="Tip:">
+          Unlike Satori, Grafex supports the full CSS spec because it renders in a real browser engine. Flexbox, Grid, <InlineCode>calc()</InlineCode>, CSS variables, <InlineCode>z-index</InlineCode>, gradients, shadows, transforms — it all works.
+      </Callout>
     </section>
 
     <!-- Props -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Props</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Compositions can accept props for dynamic content. Pass them via the CLI (<code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">--props</code>) or the API (<code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">options.props</code>).</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Props</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Compositions can accept props for dynamic content. Pass them via the CLI (<InlineCode>--props</InlineCode>) or the API (<InlineCode>options.props</InlineCode>).</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">blog-card.tsx</span>
-          <CopyButton text={`import type { CompositionConfig } from 'grafex';\n\nexport const config: CompositionConfig = { width: 1200, height: 630 };\n\ninterface Props {\n  title: string;\n  date: string;\n}\n\nexport default function BlogCard({ title, date }: Props) {\n  return (\n    <div\n      style={{\n        width: '100%',\n        height: '100%',\n        display: 'flex',\n        flexDirection: 'column',\n        justifyContent: 'center',\n        padding: '80px',\n        background: '#0f172a',\n        color: 'white',\n        fontFamily: 'system-ui, sans-serif',\n      }}\n    >\n      <div style={{ fontSize: '48px', fontWeight: 'bold' }}>{title}</div>\n      <div style={{ fontSize: '20px', color: '#94a3b8', marginTop: '16px' }}>{date}</div>\n    </div>\n  );\n}`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={propsCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="blog-card.tsx" code={propsCode} />
 
-      <p class="text-sm mb-3" style="color: var(--color-text-secondary);">Export with props:</p>
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">grafex export -f blog-card.tsx -o card.png --props '{"{"}"title":"My Post","date":"March 2026"{"}"}'</code>
-        </div>
-      </div>
+      <p class="text-sm mb-3 text-body">Export with props:</p>
+      <CodeBlock lang="bash" code={propsExportCmd} />
     </section>
 
     <!-- Example: OG Card -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Example: OG Card</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Here's a complete OG image composition and its rendered output. This is the kind of thing you'd generate at build time for every blog post.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Example: OG Card</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Here's a complete OG image composition and its rendered output. This is the kind of thing you'd generate at build time for every blog post.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">og-card.tsx</span>
-          <CopyButton text={ogCardFullCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={ogCardFullCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="og-card.tsx" code={ogCardFullCode} />
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">og-card.png</span>
-          <span class="text-xs" style="color: var(--color-text-muted);">600 × 400</span>
+      <div class="rounded-xl overflow-hidden border border-edge">
+        <div class="flex items-center justify-between px-4 py-2 border-b bg-surface border-edge">
+          <span class="text-xs font-mono text-muted">og-card.png</span>
+          <span class="text-xs text-muted">600 × 400</span>
         </div>
-        <div style="background: repeating-conic-gradient(var(--color-bg-surface) 0% 25%, var(--color-bg-surface-hover) 0% 50%) 0 0 / 16px 16px; padding: 24px; display: flex; justify-content: center;">
+        <div class="checkerboard p-6 flex justify-center">
           <img
             src="/examples/og-card.png"
             alt="Rendered OG card: Building Modern APIs"
             width="600"
             height="400"
-            style="max-width: 100%; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.5);"
+            class="max-w-full rounded-lg shadow-lg"
             loading="lazy"
           />
         </div>
@@ -593,73 +488,32 @@ await close();`;
 
     <!-- Custom Components -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Custom Components</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Compositions can import and use components from other files. Grafex bundles everything with esbuild before rendering.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Custom Components</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Compositions can import and use components from other files. Grafex bundles everything with esbuild before rendering.</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">components/badge.tsx</span>
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={badgeComponentCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="components/badge.tsx" code={badgeComponentCode} showCopy={false} class="mb-6" />
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">og-image.tsx</span>
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={usingComponentCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="og-image.tsx" code={usingComponentCode} showCopy={false} />
     </section>
 
     <!-- Variants -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Variants</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">
-        Produce multiple outputs from a single composition — different sizes, formats, or props. Define a <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">variants</code> record in your config. Each variant inherits from the base config and can override any field.
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Variants</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">
+        Produce multiple outputs from a single composition — different sizes, formats, or props. Define a <InlineCode>variants</InlineCode> record in your config. Each variant inherits from the base config and can override any field.
       </p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={variantsConfigCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={variantsConfigCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={variantsConfigCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">CLI usage</h3>
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text={variantsCliCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={variantsCliCode} lang="bash" theme={grafexTheme} />
-        </div>
-      </div>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">CLI usage</h3>
+      <CodeBlock lang="bash" code={variantsCliCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">API usage</h3>
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">TypeScript</span>
-          <CopyButton text={variantsApiCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={variantsApiCode} lang="typescript" theme={grafexTheme} />
-        </div>
-      </div>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">API usage</h3>
+      <CodeBlock lang="typescript" code={variantsApiCode} class="mb-6" />
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Merge rules: </span>
-          CLI/API options override variant config, which overrides base config. Props are shallow-merged: variant props apply first, then CLI/API props override individual keys. Array fields (<code class="font-mono">fonts</code>, <code class="font-mono">css</code>) replace rather than merge. <code class="font-mono">htmlAttributes</code> are shallow-merged: variant attributes are spread over base config attributes.
-        </p>
-      </div>
+      <Callout type="lime" label="Merge rules:">
+          CLI/API options override variant config, which overrides base config. Props are shallow-merged: variant props apply first, then CLI/API props override individual keys. Array fields (<InlineCode>fonts</InlineCode>, <InlineCode>css</InlineCode>) replace rather than merge. <InlineCode>htmlAttributes</InlineCode> are shallow-merged: variant attributes are spread over base config attributes.
+      </Callout>
     </section>
   </article>
 </DocsLayout>

--- a/website/src/pages/docs/examples.astro
+++ b/website/src/pages/docs/examples.astro
@@ -1,8 +1,6 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const examples = [
   {
@@ -62,46 +60,27 @@ const sources = Object.fromEntries(
 
 <DocsLayout title="Examples" currentPage="/docs/examples" description="Real compositions you can copy, modify, and render.">
   <div class="max-w-4xl">
-    <h1 class="font-heading text-4xl font-bold mb-4" style="color: var(--color-text-primary);">Examples</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">
+    <h1 class="font-heading text-4xl font-bold mb-4 text-heading">Examples</h1>
+    <p class="text-lg mb-12 text-body">
       Real compositions you can copy, modify, and render. Each example shows the rendered output and the full source code.
     </p>
 
     <div class="space-y-16">
       {examples.map((ex) => (
         <div>
-          <h2 class="font-heading text-2xl font-semibold mb-2" style="color: var(--color-text-primary);">{ex.title}</h2>
-          <p class="text-base mb-4" style="color: var(--color-text-secondary);">{ex.desc}</p>
+          <h2 class="font-heading text-2xl font-semibold mb-2 text-heading">{ex.title}</h2>
+          <p class="text-base mb-4 text-body">{ex.desc}</p>
 
           {/* Rendered image */}
-          <div class="checkerboard rounded-xl overflow-hidden border mb-4 flex items-center justify-center p-4" style="border-color: var(--color-border-default);">
-            <img src={ex.img} alt={ex.title} class="block rounded-lg" style="max-width: 600px; width: 100%;" loading="lazy" />
+          <div class="checkerboard rounded-xl overflow-hidden border mb-4 flex items-center justify-center p-4 border-edge">
+            <img src={ex.img} alt={ex.title} class="block rounded-lg w-full max-w-[600px]" loading="lazy" />
           </div>
 
           {/* CLI command */}
-          <div class="rounded-lg px-4 py-3 flex items-center justify-between gap-3 border mb-4" style="background: var(--color-bg-code); border-color: var(--color-border-default);">
-            <div class="flex items-center gap-3 overflow-x-auto">
-              <span class="font-mono text-sm flex-shrink-0" style="color: var(--color-text-muted);">$</span>
-              <code class="font-mono text-sm whitespace-nowrap" style="color: var(--color-accent-lime);">{ex.cmd}</code>
-            </div>
-            <CopyButton text={ex.cmd} client:load />
-          </div>
+          <CodeBlock lang="bash" code={ex.cmd} />
 
           {/* Collapsible source */}
-          <details class="group rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-            <summary class="flex items-center justify-between px-4 py-3 cursor-pointer select-none hover:bg-[var(--color-bg-surface-hover)] transition-colors list-none [&::-webkit-details-marker]:hidden" style="background: var(--color-bg-surface);">
-              <div class="flex items-center gap-3">
-                <svg class="w-4 h-4 transition-transform duration-200 group-open:rotate-90" style="color: var(--color-text-muted);" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <polyline points="9 6 15 12 9 18" />
-                </svg>
-                <span class="text-xs font-mono" style="color: var(--color-text-muted);">{ex.file}</span>
-              </div>
-              <CopyButton text={sources[ex.file]} client:load />
-            </summary>
-            <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 400px; overflow-y: auto;">
-              <Code code={sources[ex.file]} lang="tsx" theme={grafexTheme} />
-            </div>
-          </details>
+          <CodeBlock collapsible lang="tsx" label={ex.file} code={sources[ex.file]} maxHeight="400px" />
         </div>
       ))}
     </div>

--- a/website/src/pages/docs/getting-started.astro
+++ b/website/src/pages/docs/getting-started.astro
@@ -1,8 +1,8 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import InlineCode from '../../components/InlineCode.astro';
+import Callout from '../../components/Callout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const cardCode = `import type { CompositionConfig } from 'grafex';
 
@@ -148,159 +148,105 @@ export default function OgCard() {
   currentPage="/docs/getting-started"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">Getting Started</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">Go from zero to a rendered image in under 5 minutes.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">Getting Started</h1>
+    <p class="text-lg mb-12 text-body">Go from zero to a rendered image in under 5 minutes.</p>
 
     <!-- Install -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Install</h2>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Install</h2>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npm install grafex" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npm install grafex</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npm install grafex" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Grafex uses WebKit for rendering. The browser binary is downloaded automatically during <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">npm install</code> via a postinstall script — no extra steps needed.
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Grafex uses WebKit for rendering. The browser binary is downloaded automatically during <InlineCode>npm install</InlineCode> via a postinstall script — no extra steps needed.
       </p>
 
       <!-- Tip callout -->
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Tip: </span>
+      <Callout type="lime" label="Tip:">
           If the postinstall download fails (corporate firewalls, restricted CI environments), see
-          <a href="/docs/browser-setup" style="color: var(--color-primary);">Browser Setup</a> for manual installation.
-        </p>
-      </div>
+          <a href="/docs/browser-setup" class="text-pink">Browser Setup</a> for manual installation.
+      </Callout>
 
-      <p class="text-sm mt-4" style="color: var(--color-text-secondary);"><strong style="color: var(--color-text-primary);">Requirements:</strong> Node.js &gt;= 20.0.0</p>
+      <p class="text-sm mt-4 text-body"><strong class="text-heading">Requirements:</strong> Node.js &gt;= 20.0.0</p>
     </section>
 
     <!-- Write a composition -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Write a composition</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">Create a file called <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">card.tsx</code>:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Write a composition</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">Create a file called <InlineCode>card.tsx</InlineCode>:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={cardCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={cardCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={cardCode} class="mb-6" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">A composition has two parts:</p>
-      <ol class="list-decimal list-inside space-y-2 text-base" style="color: var(--color-text-secondary);">
-        <li><strong style="color: var(--color-text-primary);">Default export</strong> — a function that returns JSX. This is your image layout.</li>
-        <li><strong style="color: var(--color-text-primary);">Named <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config</code> export</strong> — a <code class="font-mono text-sm px-1 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">CompositionConfig</code> object that sets the output dimensions, format, and optional features like custom fonts and CSS files.</li>
+      <p class="text-base leading-relaxed mb-4 text-body">A composition has two parts:</p>
+      <ol class="list-decimal list-inside space-y-2 text-base text-body">
+        <li><strong class="text-heading">Default export</strong> — a function that returns JSX. This is your image layout.</li>
+        <li><strong class="text-heading">Named <InlineCode>config</InlineCode> export</strong> — a <InlineCode>CompositionConfig</InlineCode> object that sets the output dimensions, format, and optional features like custom fonts and CSS files.</li>
       </ol>
     </section>
 
     <!-- TypeScript Setup -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">TypeScript Setup</h2>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Run <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">grafex init</code> to generate the correct <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">tsconfig.json</code> automatically:
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">TypeScript Setup</h2>
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Run <InlineCode>grafex init</InlineCode> to generate the correct <InlineCode>tsconfig.json</InlineCode> automatically:
       </p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npx grafex init" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx grafex init</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npx grafex init" class="mb-6" />
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        This creates a <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">tsconfig.json</code> and a starter <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">composition.tsx</code> in your current directory. Existing files are never overwritten.
+      <p class="text-base leading-relaxed mb-4 text-body">
+        This creates a <InlineCode>tsconfig.json</InlineCode> and a starter <InlineCode>composition.tsx</InlineCode> in your current directory. Existing files are never overwritten.
       </p>
 
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Or add these compiler options to your <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">tsconfig.json</code> manually:
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Or add these compiler options to your <InlineCode>tsconfig.json</InlineCode> manually:
       </p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">tsconfig.json</span>
-          <CopyButton text={`{\n  "compilerOptions": {\n    "jsx": "react",\n    "jsxFactory": "h",\n    "jsxFragmentFactory": "Fragment"\n  }\n}`} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-          <Code code={`{\n  "compilerOptions": {\n    "jsx": "react",\n    "jsxFactory": "h",\n    "jsxFragmentFactory": "Fragment"\n  }\n}`} lang="json" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="json" label="tsconfig.json" code={`{\n  "compilerOptions": {\n    "jsx": "react",\n    "jsxFactory": "h",\n    "jsxFragmentFactory": "Fragment"\n  }\n}`} />
 
-      <p class="text-base leading-relaxed" style="color: var(--color-text-secondary);">
-        Grafex ships its own JSX type definitions. They are picked up automatically once the package is installed — no extra imports needed. The <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">h</code> and <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">Fragment</code> functions are injected at transpile time, so you never import them in composition files.
+      <p class="text-base leading-relaxed text-body">
+        Grafex ships its own JSX type definitions. They are picked up automatically once the package is installed — no extra imports needed. The <InlineCode>h</InlineCode> and <InlineCode>Fragment</InlineCode> functions are injected at transpile time, so you never import them in composition files.
       </p>
     </section>
 
     <!-- Export -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Export</h2>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Export</h2>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npx grafex export -f card.tsx -o card.png" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx grafex export -f card.tsx -o card.png</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npx grafex export -f card.tsx -o card.png" class="mb-6" />
 
-      <p class="text-base leading-relaxed" style="color: var(--color-text-secondary);">
+      <p class="text-base leading-relaxed text-body">
         Grafex bundles your composition with esbuild, renders it in a headless WebKit instance, and saves the screenshot as an image. The output is a 1200×630 image with your gradient background and centered text.
       </p>
     </section>
 
     <!-- See it in action -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">See it in action</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">This is the kind of image Grafex can generate. Write the code, run one command, see the result — no browser window, no server.</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">See it in action</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">This is the kind of image Grafex can generate. Write the code, run one command, see the result — no browser window, no server.</p>
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <!-- Code pane -->
-        <div class="border-b" style="border-color: var(--color-border-default);">
-          <div class="flex items-center justify-between px-4 py-2.5 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs font-mono" style="color: var(--color-text-muted);">og-card.tsx</span>
-          </div>
-          <div class="overflow-x-auto [&_pre]:p-5 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-            <Code code={ogCardCode} lang="tsx" theme={grafexTheme} />
-          </div>
-        </div>
+      <div class="rounded-xl overflow-hidden border border-edge">
+        <CodeBlock label="og-card.tsx" code={ogCardCode} lang="tsx" maxHeight="500px" class="rounded-none border-0 mb-0" />
 
         <!-- Image pane -->
-        <div class="checkerboard flex flex-col items-center justify-center p-6 relative">
+        <div class="checkerboard flex flex-col items-center justify-center p-6 relative border-t border-edge">
           <img
             src="/examples/og-card.png"
             alt="Rendered OG card composition output"
             width="600"
             height="400"
-            style="width: 100%; max-width: 480px; border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.5);"
+            class="w-full max-w-[480px] rounded-[10px] shadow-lg"
             loading="lazy"
           />
-          <span class="absolute bottom-3 right-4 text-xs font-mono" style="color: var(--color-text-muted);">og-card.png</span>
+          <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">og-card.png</span>
         </div>
       </div>
 
-      <div class="mt-4 rounded-xl px-4 py-3 flex items-start gap-3 overflow-x-auto border" style="background: var(--color-bg-code); border-color: var(--color-border-default);">
-        <span class="font-mono text-sm flex-shrink-0 mt-0.5" style="color: var(--color-text-muted);">$</span>
-        <code class="font-mono text-sm whitespace-nowrap" style="color: var(--color-accent-lime);">npx grafex export -f og-card.tsx -o og-card.png</code>
-      </div>
+      <CodeBlock lang="bash" code="npx grafex export -f og-card.tsx -o og-card.png" class="mt-4" />
     </section>
 
     <!-- Next steps -->
     <section>
-      <h2 class="font-heading font-bold text-2xl mb-6" style="color: var(--color-text-primary);">Next steps</h2>
+      <h2 class="font-heading font-bold text-2xl mb-6 text-heading">Next steps</h2>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {[
           { href: '/docs/compositions', title: 'Compositions', desc: 'Props, custom components, styling patterns' },
@@ -309,10 +255,10 @@ export default function OgCard() {
         ].map((item) => (
           <a
             href={item.href}
-            class="block rounded-xl p-5 border transition-all duration-200 bg-[var(--color-bg-surface)] border-[var(--color-border-default)] hover:border-[var(--color-border-strong)] hover:shadow-md"
+            class="block rounded-xl p-5 border transition-all duration-200 bg-surface border-edge hover:border-edge-strong hover:shadow-md"
           >
-            <div class="font-semibold mb-1" style="color: var(--color-primary);">{item.title}</div>
-            <div class="text-sm" style="color: var(--color-text-secondary);">{item.desc}</div>
+            <div class="font-semibold mb-1 text-pink">{item.title}</div>
+            <div class="text-sm text-body">{item.desc}</div>
           </a>
         ))}
       </div>

--- a/website/src/pages/docs/tailwind.astro
+++ b/website/src/pages/docs/tailwind.astro
@@ -1,8 +1,8 @@
 ---
 import DocsLayout from '../../layouts/DocsLayout.astro';
-import CopyButton from '../../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../../shiki-theme';
+import InlineCode from '../../components/InlineCode.astro';
+import Callout from '../../components/Callout.astro';
+import CodeBlock from '../../components/CodeBlock.astro';
 
 const inputCssCode = `@import "tailwindcss";`;
 
@@ -80,153 +80,96 @@ const buildCmd = `npx @tailwindcss/cli -i ./input.css -o ./styles.css && npx gra
   currentPage="/docs/tailwind"
 >
   <article>
-    <h1 class="font-heading font-bold text-4xl mb-2" style="color: var(--color-text-primary);">Using Tailwind CSS</h1>
-    <p class="text-lg mb-12" style="color: var(--color-text-secondary);">Grafex works with Tailwind CSS out of the box. No plugins, no special config — just generate a CSS file and reference it in your composition.</p>
+    <h1 class="font-heading font-bold text-4xl mb-2 text-heading">Using Tailwind CSS</h1>
+    <p class="text-lg mb-12 text-body">Grafex works with Tailwind CSS out of the box. No plugins, no special config — just generate a CSS file and reference it in your composition.</p>
 
     <!-- Overview -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">How it works</h2>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        Grafex's <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code> field accepts an array of local CSS file paths. It's a generic injection mechanism — Grafex reads each file from disk and injects its contents as a <code class="font-mono">&lt;style&gt;</code> tag before rendering. This means any CSS preprocessor output works: plain CSS, Tailwind, Sass, PostCSS — anything that produces a <code class="font-mono">.css</code> file.
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">How it works</h2>
+      <p class="text-base leading-relaxed mb-4 text-body">
+        Grafex's <InlineCode>config.css</InlineCode> field accepts an array of local CSS file paths. It's a generic injection mechanism — Grafex reads each file from disk and injects its contents as a <InlineCode>&lt;style&gt;</InlineCode> tag before rendering. This means any CSS preprocessor output works: plain CSS, Tailwind, Sass, PostCSS — anything that produces a <InlineCode>.css</InlineCode> file.
       </p>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">
-        The Tailwind workflow is: run Tailwind's CLI to compile your input file into a CSS output, then point <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code> at that output. In dev mode, Tailwind's <code class="font-mono">--watch</code> flag recompiles on every file change, and Grafex watches the CSS file and re-renders automatically.
+      <p class="text-base leading-relaxed mb-6 text-body">
+        The Tailwind workflow is: run Tailwind's CLI to compile your input file into a CSS output, then point <InlineCode>config.css</InlineCode> at that output. In dev mode, Tailwind's <InlineCode>--watch</InlineCode> flag recompiles on every file change, and Grafex watches the CSS file and re-renders automatically.
       </p>
 
-      <div class="rounded-xl p-4 border-l-4" style="background: rgba(163,230,53,0.08); border-left-color: var(--color-accent-lime);">
-        <p class="text-sm leading-relaxed" style="color: var(--color-text-primary);">
-          <span class="font-semibold" style="color: var(--color-accent-lime);">Key DX feature: </span>
-          <code class="font-mono">grafex dev</code> watches all files listed in <code class="font-mono">config.css</code>. When Tailwind's <code class="font-mono">--watch</code> rewrites <code class="font-mono">styles.css</code>, Grafex detects the change and re-renders within ~100ms. The two tools compose naturally — edit your composition, see the result instantly. If <code class="font-mono">styles.css</code> doesn't exist yet at startup, <code class="font-mono">grafex dev</code> renders without it and re-renders as soon as the file appears — so <code class="font-mono">concurrently</code> just works with no pre-build step.
-        </p>
-      </div>
+      <Callout type="lime" label="Key DX feature:">
+          <InlineCode>grafex dev</InlineCode> watches all files listed in <InlineCode>config.css</InlineCode>. When Tailwind's <InlineCode>--watch</InlineCode> rewrites <InlineCode>styles.css</InlineCode>, Grafex detects the change and re-renders within ~100ms. The two tools compose naturally — edit your composition, see the result instantly. If <InlineCode>styles.css</InlineCode> doesn't exist yet at startup, <InlineCode>grafex dev</InlineCode> renders without it and re-renders as soon as the file appears — so <InlineCode>concurrently</InlineCode> just works with no pre-build step.
+      </Callout>
     </section>
 
     <!-- Setup -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Setup</h2>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Setup</h2>
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">1. Install dependencies</h3>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">1. Install dependencies</h3>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text="npm install --save-dev @tailwindcss/cli concurrently" client:load />
-        </div>
-        <div class="px-4 py-3" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npm install --save-dev @tailwindcss/cli concurrently</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code="npm install --save-dev @tailwindcss/cli concurrently" class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">2. Create your CSS input file</h3>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Create <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">input.css</code> in the same directory as your composition:</p>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">2. Create your CSS input file</h3>
+      <p class="text-base leading-relaxed mb-4 text-body">Create <InlineCode>input.css</InlineCode> in the same directory as your composition:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">input.css</span>
-          <CopyButton text={inputCssCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-          <Code code={inputCssCode} lang="css" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="css" label="input.css" code={inputCssCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">3. Write your composition</h3>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Reference the compiled output in <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">config.css</code> and use Tailwind utility classes via <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">className</code>:</p>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">3. Write your composition</h3>
+      <p class="text-base leading-relaxed mb-4 text-body">Reference the compiled output in <InlineCode>config.css</InlineCode> and use Tailwind utility classes via <InlineCode>className</InlineCode>:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-6" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-          <CopyButton text={cardCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 500px; overflow-y: auto;">
-          <Code code={cardCode} lang="tsx" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="tsx" label="card.tsx" code={cardCode} class="mb-6" />
 
-      <h3 class="font-heading font-semibold text-lg mb-3" style="color: var(--color-text-primary);">4. Add npm scripts</h3>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Add these scripts to your <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">package.json</code>:</p>
+      <h3 class="font-heading font-semibold text-lg mb-3 text-heading">4. Add npm scripts</h3>
+      <p class="text-base leading-relaxed mb-4 text-body">Add these scripts to your <InlineCode>package.json</InlineCode>:</p>
 
-      <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs font-mono" style="color: var(--color-text-muted);">package.json</span>
-          <CopyButton text={packageJsonCode} client:load />
-        </div>
-        <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed">
-          <Code code={packageJsonCode} lang="json" theme={grafexTheme} />
-        </div>
-      </div>
+      <CodeBlock lang="json" label="package.json" code={packageJsonCode} />
     </section>
 
     <!-- Development workflow -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Development workflow</h2>
-      <p class="text-base leading-relaxed mb-6" style="color: var(--color-text-secondary);">
-        Run <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">npm run dev</code> to start both watchers at once. Or run them separately if you prefer:
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Development workflow</h2>
+      <p class="text-base leading-relaxed mb-6 text-body">
+        Run <InlineCode>npm run dev</InlineCode> to start both watchers at once. Or run them separately if you prefer:
       </p>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-        <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-          <div class="px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs font-mono" style="color: var(--color-text-muted);">Terminal 1 — Tailwind watcher</span>
-          </div>
-          <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-            <code class="font-mono text-xs" style="color: var(--color-accent-lime);">{devTerminal1}</code>
-          </div>
-        </div>
-        <div class="rounded-xl overflow-hidden border self-start" style="border-color: var(--color-border-default);">
-          <div class="px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs font-mono" style="color: var(--color-text-muted);">Terminal 2 — Grafex dev server</span>
-          </div>
-          <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-            <code class="font-mono text-xs" style="color: var(--color-accent-lime);">{devTerminal2}</code>
-          </div>
-        </div>
+        <CodeBlock lang="bash" label="Terminal 1 — Tailwind watcher" code={devTerminal1} showCopy={false} class="mb-0" />
+        <CodeBlock lang="bash" label="Terminal 2 — Grafex dev server" code={devTerminal2} showCopy={false} class="self-start mb-0" />
       </div>
 
-      <p class="text-base leading-relaxed" style="color: var(--color-text-secondary);">
-        Open <code class="font-mono text-sm px-1.5 py-0.5 rounded" style="color: var(--color-primary); background: rgba(244,114,182,0.1);">http://localhost:3000</code> to see the live preview. Edit your composition — the preview updates automatically.
+      <p class="text-base leading-relaxed text-body">
+        Open <InlineCode>http://localhost:3000</InlineCode> to see the live preview. Edit your composition — the preview updates automatically.
       </p>
     </section>
 
     <!-- Production build -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Production build</h2>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">Compile the CSS once, then export the composition:</p>
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Production build</h2>
+      <p class="text-base leading-relaxed mb-4 text-body">Compile the CSS once, then export the composition:</p>
 
-      <div class="rounded-xl overflow-hidden border mb-4" style="border-color: var(--color-border-default);">
-        <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-          <CopyButton text={buildCmd} client:load />
-        </div>
-        <div class="px-4 py-3 overflow-x-auto" style="background: var(--color-bg-code);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">{buildCmd}</code>
-        </div>
-      </div>
+      <CodeBlock lang="bash" code={buildCmd} />
 
-      <p class="text-sm" style="color: var(--color-text-secondary);">Or use the <code class="font-mono" style="color: var(--color-primary);">npm run build</code> script from the setup step above.</p>
+      <p class="text-sm text-body">Or use the <InlineCode>npm run build</InlineCode> script from the setup step above.</p>
     </section>
 
     <!-- Working example -->
     <section class="mb-12">
-      <h2 class="font-heading font-bold text-2xl mb-4" style="color: var(--color-text-primary);">Working example</h2>
-      <p class="text-base leading-relaxed mb-4" style="color: var(--color-text-secondary);">
-        The <a href="https://github.com/grafex-dev/grafex/tree/main/examples/tailwind" style="color: var(--color-primary);">examples/tailwind/</a> directory in the repository contains a complete runnable example with all the files described on this page.
+      <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Working example</h2>
+      <p class="text-base leading-relaxed mb-4 text-body">
+        The <a href="https://github.com/grafex-dev/grafex/tree/main/examples/tailwind" class="text-pink">examples/tailwind/</a> directory in the repository contains a complete runnable example with all the files described on this page.
       </p>
 
-      <div class="rounded-xl p-5 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-        <p class="text-sm font-semibold mb-3" style="color: var(--color-text-primary);">Files in examples/tailwind/</p>
-        <ul class="space-y-1.5 text-sm font-mono" style="color: var(--color-text-secondary);">
-          <li><span style="color: var(--color-accent-lime);">input.css</span> — Tailwind CSS entry point</li>
-          <li><span style="color: var(--color-accent-lime);">card.tsx</span> — OG card composition using Tailwind classes</li>
-          <li><span style="color: var(--color-accent-lime);">package.json</span> — dev and build scripts</li>
-          <li><span style="color: var(--color-accent-lime);">tsconfig.json</span> — TypeScript/JSX settings</li>
+      <div class="rounded-xl p-5 border bg-surface border-edge">
+        <p class="text-sm font-semibold mb-3 text-heading">Files in examples/tailwind/</p>
+        <ul class="space-y-1.5 text-sm font-mono text-body">
+          <li><span class="text-lime">input.css</span> — Tailwind CSS entry point</li>
+          <li><span class="text-lime">card.tsx</span> — OG card composition using Tailwind classes</li>
+          <li><span class="text-lime">package.json</span> — dev and build scripts</li>
+          <li><span class="text-lime">tsconfig.json</span> — TypeScript/JSX settings</li>
         </ul>
       </div>
     </section>
 
     <!-- Notes -->
     <section>
-      <h2 class="font-heading font-bold text-2xl mb-6" style="color: var(--color-text-primary);">Related</h2>
+      <h2 class="font-heading font-bold text-2xl mb-6 text-heading">Related</h2>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {[
           { href: '/docs/compositions', title: 'Compositions', desc: 'CSS files, styling patterns, and the full config reference' },
@@ -234,10 +177,10 @@ const buildCmd = `npx @tailwindcss/cli -i ./input.css -o ./styles.css && npx gra
         ].map((item) => (
           <a
             href={item.href}
-            class="block rounded-xl p-5 border transition-all duration-200 bg-[var(--color-bg-surface)] border-[var(--color-border-default)] hover:border-[var(--color-border-strong)] hover:shadow-md"
+            class="block rounded-xl p-5 border transition-all duration-200 bg-surface border-edge hover:border-edge-strong hover:shadow-md"
           >
-            <div class="font-semibold mb-1" style="color: var(--color-primary);">{item.title}</div>
-            <div class="text-sm" style="color: var(--color-text-secondary);">{item.desc}</div>
+            <div class="font-semibold mb-1 text-pink">{item.title}</div>
+            <div class="text-sm text-body">{item.desc}</div>
           </a>
         ))}
       </div>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import MarketingLayout from '../layouts/MarketingLayout.astro';
 import CopyButton from '../components/CopyButton.tsx';
 import CodeBlock from '../components/CodeBlock.astro';
 
@@ -190,375 +190,268 @@ export default function OgCard() {
 }`;
 ---
 
-<BaseLayout
+<MarketingLayout
   title="Grafex — Images as Code"
   description="Write JSX compositions with full CSS support. Export as images. No browser window, no server, no ceremony."
 >
-  <!-- Skip to content -->
-  <a
-    href="#main-content"
-    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
-  >
-    Skip to content
-  </a>
+  <!-- Hero Section -->
+  <section class="relative pt-40 pb-24 px-6 overflow-hidden text-center">
+    <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(ellipse at 50% 0%, rgba(244, 114, 182, 0.12), transparent 70%);"></div>
 
-  <!-- Navigation -->
-  <header id="site-nav" class="fixed top-0 left-0 right-0 z-40 h-16 transition-all duration-300 border-b border-transparent">
-    <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
-      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-heading">Grafex</a>
+    <div class="relative max-w-4xl mx-auto">
+      <!-- Eyebrow badge -->
+      <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider mb-8 border text-lime bg-lime-muted border-lime/20">
+        Open Source
+      </div>
 
-      <!-- Desktop nav -->
-      <nav class="hidden md:flex items-center gap-8">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
-        <a href="#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-      </nav>
+      <!-- Headline -->
+      <h1 class="font-heading font-bold text-5xl md:text-6xl lg:text-7xl leading-tight tracking-tight mb-6 gradient-text">
+        Images as Code.
+      </h1>
 
-      <div class="hidden md:block">
+      <!-- Subheadline -->
+      <p class="text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed text-body">
+        Write JSX compositions with full CSS support. Export as images. No browser window, no server, no ceremony.
+      </p>
+
+      <!-- Install command -->
+      <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mx-auto mb-8 border bg-surface border-edge">
+        <code class="font-mono text-sm text-lime">npm install grafex</code>
+        <CopyButton text="npm install grafex" client:load />
+      </div>
+
+      <!-- CTA buttons -->
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
         <a
           href="/docs/getting-started"
-          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 gradient-cta"
+          class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
         >
           Get Started
         </a>
+        <a
+          href="https://github.com/grafex-dev/grafex"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+          </svg>
+          View on GitHub
+        </a>
       </div>
 
-      <!-- Mobile hamburger -->
-      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors text-body" aria-label="Open menu" aria-expanded="false">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-          <line x1="3" y1="6" x2="21" y2="6"/>
-          <line x1="3" y1="12" x2="21" y2="12"/>
-          <line x1="3" y1="18" x2="21" y2="18"/>
-        </svg>
-      </button>
-    </div>
+      <!-- Hero demo: Code + Output -->
+      <div class="max-w-4xl mx-auto rounded-2xl overflow-hidden border border-edge shadow-lg">
+        <div class="flex flex-col lg:flex-row">
+          <!-- Left pane: Code -->
+          <div class="flex-1 border-b lg:border-b-0 lg:border-r border-edge-strong">
+            <CodeBlock label="card.tsx" code={heroCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
+          </div>
 
-    <!-- Mobile menu -->
-    <div id="mobile-menu" class="hidden md:hidden border-t bg-base border-edge">
-      <nav class="px-6 py-4 flex flex-col gap-4">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
-        <a href="#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta hover:brightness-110 transition-all">
+          <!-- Right pane: Output -->
+          <div class="checkerboard lg:w-[45%] flex flex-col items-center justify-center p-8 relative min-h-48">
+            <div class="w-full rounded-xl overflow-hidden shadow-lg flex items-center justify-center aspect-[1200/630] max-w-[360px]" style="background: linear-gradient(135deg, #667eea, #764ba2);">
+              <span class="text-white font-bold text-center p-4" style="font-size: clamp(14px, 3.5vw, 24px); font-family: system-ui, sans-serif;">Hello, Grafex!</span>
+            </div>
+            <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">output.png</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Why Grafex -->
+  <section id="why-grafex" class="py-24 px-6 border-t border-edge">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-16">
+        <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Why Grafex?</h2>
+        <p class="text-lg max-w-2xl mx-auto text-body">Full CSS. Real browser engine. Zero configuration. The image composition tool you actually wanted.</p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-pink hover:border-t-pink">
+          <div class="mb-4 text-pink">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a1 1 0 0 0-3-3Z"/><path d="M9 8c-2 3-4 3.5-7 4l8 8c1-.5 3.5-2 4-7"/><path d="M14.5 17.5 4.5 15"/>
+            </svg>
+          </div>
+          <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Full CSS Support</h3>
+          <p class="text-sm leading-relaxed text-body">Flexbox, Grid, gradients, shadows, custom fonts — real CSS rendered by a real browser engine. Not a subset. Not reimplemented. The real thing.</p>
+        </div>
+
+        <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-lime hover:border-t-lime">
+          <div class="mb-4 text-lime">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+            </svg>
+          </div>
+          <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Fast Renders</h3>
+          <p class="text-sm leading-relaxed text-body">5-50ms warm renders. Sub-second cold starts. WebKit launches once and stays ready.</p>
+        </div>
+
+        <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-sky hover:border-t-sky">
+          <div class="mb-4 text-sky">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/>
+            </svg>
+          </div>
+          <h3 class="font-heading font-semibold text-lg mb-2 text-heading">AI-Friendly</h3>
+          <p class="text-sm leading-relaxed text-body">Compositions are plain JSX functions. Any LLM can write them, modify them, and reason about them.</p>
+        </div>
+
+        <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-amber hover:border-t-amber">
+          <div class="mb-4 text-amber">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>
+            </svg>
+          </div>
+          <h3 class="font-heading font-semibold text-lg mb-2 text-heading">No Browser Window</h3>
+          <p class="text-sm leading-relaxed text-body">WebKit runs headlessly behind the scenes. No Puppeteer scripts. No browser lifecycle management. Just import, render, done.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Code Example -->
+  <section id="code-example" class="py-24 px-6 border-t border-edge">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-16">
+        <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Compositions Are Just Functions</h2>
+        <p class="text-lg max-w-2xl mx-auto text-body">A composition is a TSX file that exports a function and a config. Accept props, use components, style with CSS — all the patterns you already know.</p>
+      </div>
+
+      <!-- Code + Output: unified container -->
+      <div class="rounded-xl overflow-hidden border border-edge">
+        <CodeBlock label="og-card.tsx" code={ogCardCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
+        <!-- Output image: directly below code, no gap, shares border -->
+        <div class="checkerboard border-t border-edge relative flex items-center justify-center p-6">
+          <img src="/examples/og-card.png" alt="Generated OG card showing 'Building Modern APIs'" class="rounded-lg shadow-2xl w-full max-w-[600px]" />
+          <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">og-card.png</span>
+        </div>
+      </div>
+
+      <!-- CLI command -->
+      <CodeBlock lang="bash" code="npx grafex export -f og-card.tsx -o og-card.png" class="mt-4" />
+
+      <p class="text-center mt-6">
+        <a href="/docs/examples" class="text-sm font-medium transition-colors duration-150 no-underline hover:no-underline text-pink hover:text-pink-hover">See more examples →</a>
+      </p>
+    </div>
+  </section>
+
+  <!-- Use Cases -->
+  <section id="use-cases" class="py-24 px-6 border-t border-edge">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-16">
+        <h2 class="font-heading font-bold text-4xl mb-4 text-heading">What You Can Build</h2>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {[
+          { title: 'Open Graph Images', desc: 'Dynamic social previews for every page, generated at build time.', img: '/examples/og-card.png' },
+          { title: 'Social Media Cards', desc: 'Branded cards for Twitter, LinkedIn, and Instagram — from one template.', img: '/examples/social-card.png' },
+          { title: 'Email & Web Banners', desc: 'Programmatic banner generation with consistent branding across campaigns.', img: '/examples/banner.png' },
+          { title: 'Certificates', desc: 'Event certificates and awards with dynamic names, dates, and details.', img: '/examples/certificate.png' },
+          { title: 'Video Thumbnails', desc: 'YouTube and podcast covers generated from a single template.', img: '/examples/thumbnail.png' },
+          { title: 'Diagrams & Charts', desc: 'Architecture diagrams and data visualizations, version-controlled as code.', img: '/examples/diagram.png' },
+        ].map((item) => (
+          <div class="rounded-xl border transition-all duration-200 hover:border-edge-strong hover:shadow-md overflow-hidden bg-surface border-edge">
+            <div class="checkerboard border-b border-edge overflow-hidden aspect-[1200/630]">
+              <img src={item.img} alt={item.title} width="600" height="400" class="w-full h-full object-contain block" loading="lazy" />
+            </div>
+            <div class="p-6">
+              <h3 class="font-heading font-semibold text-lg mb-2 text-heading">{item.title}</h3>
+              <p class="text-sm leading-relaxed text-body">{item.desc}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Getting Started Steps -->
+  <section id="getting-started" class="py-24 px-6 border-t border-edge">
+    <div class="max-w-3xl mx-auto">
+      <div class="text-center mb-16">
+        <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Get Started in 3 Steps</h2>
+      </div>
+
+      <div class="space-y-12">
+        <!-- Step 1 -->
+        <div>
+          <div class="flex items-center gap-4 mb-4">
+            <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+              <span class="font-heading font-bold text-base text-pink">1</span>
+            </div>
+            <h3 class="font-heading font-semibold text-2xl text-heading">Install</h3>
+          </div>
+          <p class="text-base mb-4 ml-14 text-body">One package. WebKit is downloaded automatically.</p>
+          <div class="ml-14">
+            <CodeBlock lang="bash" code="npm install grafex" />
+          </div>
+        </div>
+
+        <!-- Step 2 -->
+        <div>
+          <div class="flex items-center gap-4 mb-4">
+            <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+              <span class="font-heading font-bold text-base text-pink">2</span>
+            </div>
+            <h3 class="font-heading font-semibold text-2xl text-heading">Write a composition</h3>
+          </div>
+          <p class="text-base mb-4 ml-14 text-body">Create a TSX file. Export a component and a config.</p>
+          <CodeBlock lang="tsx" label="card.tsx" code={step2Code} maxHeight="400px" class="ml-14" />
+        </div>
+
+        <!-- Step 3 -->
+        <div>
+          <div class="flex items-center gap-4 mb-4">
+            <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+              <span class="font-heading font-bold text-base text-pink">3</span>
+            </div>
+            <h3 class="font-heading font-semibold text-2xl text-heading">Export</h3>
+          </div>
+          <p class="text-base mb-4 ml-14 text-body">Run one command. Get an image.</p>
+          <div class="ml-14">
+            <CodeBlock lang="bash" code="npx grafex export -f card.tsx -o card.png" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Band -->
+  <section class="py-20 px-6 bg-surface border-t border-edge">
+    <div class="max-w-2xl mx-auto text-center">
+      <h2 class="font-heading font-bold text-4xl mb-8 gradient-text">
+        Start Making Images.
+      </h2>
+
+      <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mb-8 border bg-base border-edge">
+        <code class="font-mono text-sm text-lime">npm install grafex</code>
+        <CopyButton text="npm install grafex" client:load />
+      </div>
+
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a
+          href="/docs/getting-started"
+          class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
+        >
           Get Started
         </a>
-      </nav>
+        <a
+          href="https://github.com/grafex-dev/grafex"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+          </svg>
+          View on GitHub
+        </a>
+      </div>
     </div>
-  </header>
-
-  <main id="main-content">
-    <!-- Hero Section -->
-    <section class="relative pt-40 pb-24 px-6 overflow-hidden text-center">
-      <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(ellipse at 50% 0%, rgba(244, 114, 182, 0.12), transparent 70%);"></div>
-
-      <div class="relative max-w-4xl mx-auto">
-        <!-- Eyebrow badge -->
-        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider mb-8 border text-lime bg-lime-muted border-lime/20">
-          Open Source
-        </div>
-
-        <!-- Headline -->
-        <h1 class="font-heading font-bold text-5xl md:text-6xl lg:text-7xl leading-tight tracking-tight mb-6 gradient-text">
-          Images as Code.
-        </h1>
-
-        <!-- Subheadline -->
-        <p class="text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed text-body">
-          Write JSX compositions with full CSS support. Export as images. No browser window, no server, no ceremony.
-        </p>
-
-        <!-- Install command -->
-        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mx-auto mb-8 border bg-surface border-edge">
-          <code class="font-mono text-sm text-lime">npm install grafex</code>
-          <CopyButton text="npm install grafex" client:load />
-        </div>
-
-        <!-- CTA buttons -->
-        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
-          <a
-            href="/docs/getting-started"
-            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
-          >
-            Get Started
-          </a>
-          <a
-            href="https://github.com/grafex-dev/grafex"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
-            </svg>
-            View on GitHub
-          </a>
-        </div>
-
-        <!-- Hero demo: Code + Output -->
-        <div class="max-w-4xl mx-auto rounded-2xl overflow-hidden border border-edge shadow-lg">
-          <div class="flex flex-col lg:flex-row">
-            <!-- Left pane: Code -->
-            <div class="flex-1 border-b lg:border-b-0 lg:border-r border-edge-strong">
-              <CodeBlock label="card.tsx" code={heroCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
-            </div>
-
-            <!-- Right pane: Output -->
-            <div class="checkerboard lg:w-[45%] flex flex-col items-center justify-center p-8 relative min-h-48">
-              <div class="w-full rounded-xl overflow-hidden shadow-lg flex items-center justify-center" style="background: linear-gradient(135deg, #667eea, #764ba2); aspect-ratio: 1200/630; max-width: 360px;">
-                <span style="color: white; font-size: clamp(14px, 3.5vw, 24px); font-weight: bold; font-family: system-ui, sans-serif; text-align: center; padding: 1rem;">Hello, Grafex!</span>
-              </div>
-              <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">output.png</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Why Grafex -->
-    <section id="why-grafex" class="py-24 px-6 border-t border-edge">
-      <div class="max-w-6xl mx-auto">
-        <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Why Grafex?</h2>
-          <p class="text-lg max-w-2xl mx-auto text-body">Full CSS. Real browser engine. Zero configuration. The image composition tool you actually wanted.</p>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-pink hover:border-t-pink">
-            <div class="mb-4 text-pink">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a1 1 0 0 0-3-3Z"/><path d="M9 8c-2 3-4 3.5-7 4l8 8c1-.5 3.5-2 4-7"/><path d="M14.5 17.5 4.5 15"/>
-              </svg>
-            </div>
-            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Full CSS Support</h3>
-            <p class="text-sm leading-relaxed text-body">Flexbox, Grid, gradients, shadows, custom fonts — real CSS rendered by a real browser engine. Not a subset. Not reimplemented. The real thing.</p>
-          </div>
-
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-lime hover:border-t-lime">
-            <div class="mb-4 text-lime">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
-              </svg>
-            </div>
-            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Fast Renders</h3>
-            <p class="text-sm leading-relaxed text-body">5-50ms warm renders. Sub-second cold starts. WebKit launches once and stays ready.</p>
-          </div>
-
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-sky hover:border-t-sky">
-            <div class="mb-4 text-sky">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/>
-              </svg>
-            </div>
-            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">AI-Friendly</h3>
-            <p class="text-sm leading-relaxed text-body">Compositions are plain JSX functions. Any LLM can write them, modify them, and reason about them.</p>
-          </div>
-
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-amber hover:border-t-amber">
-            <div class="mb-4 text-amber">
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-                <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>
-              </svg>
-            </div>
-            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">No Browser Window</h3>
-            <p class="text-sm leading-relaxed text-body">WebKit runs headlessly behind the scenes. No Puppeteer scripts. No browser lifecycle management. Just import, render, done.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Code Example -->
-    <section id="code-example" class="py-24 px-6 border-t border-edge">
-      <div class="max-w-6xl mx-auto">
-        <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Compositions Are Just Functions</h2>
-          <p class="text-lg max-w-2xl mx-auto text-body">A composition is a TSX file that exports a function and a config. Accept props, use components, style with CSS — all the patterns you already know.</p>
-        </div>
-
-        <!-- Code + Output: unified container -->
-        <div class="rounded-xl overflow-hidden border border-edge">
-          <CodeBlock label="og-card.tsx" code={ogCardCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
-          <!-- Output image: directly below code, no gap, shares border -->
-          <div class="checkerboard border-t border-edge relative flex items-center justify-center p-6">
-            <img src="/examples/og-card.png" alt="Generated OG card showing 'Building Modern APIs'" class="rounded-lg shadow-2xl w-full max-w-[600px]" />
-            <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">og-card.png</span>
-          </div>
-        </div>
-
-        <!-- CLI command -->
-        <CodeBlock lang="bash" code="npx grafex export -f og-card.tsx -o og-card.png" class="mt-4" />
-
-        <p class="text-center mt-6">
-          <a href="/docs/examples" class="text-sm font-medium transition-colors duration-150 no-underline hover:no-underline text-pink hover:text-pink-hover">See more examples →</a>
-        </p>
-      </div>
-    </section>
-
-    <!-- Use Cases -->
-    <section id="use-cases" class="py-24 px-6 border-t border-edge">
-      <div class="max-w-6xl mx-auto">
-        <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">What You Can Build</h2>
-        </div>
-
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {[
-            { title: 'Open Graph Images', desc: 'Dynamic social previews for every page, generated at build time.', img: '/examples/og-card.png' },
-            { title: 'Social Media Cards', desc: 'Branded cards for Twitter, LinkedIn, and Instagram — from one template.', img: '/examples/social-card.png' },
-            { title: 'Email & Web Banners', desc: 'Programmatic banner generation with consistent branding across campaigns.', img: '/examples/banner.png' },
-            { title: 'Certificates', desc: 'Event certificates and awards with dynamic names, dates, and details.', img: '/examples/certificate.png' },
-            { title: 'Video Thumbnails', desc: 'YouTube and podcast covers generated from a single template.', img: '/examples/thumbnail.png' },
-            { title: 'Diagrams & Charts', desc: 'Architecture diagrams and data visualizations, version-controlled as code.', img: '/examples/diagram.png' },
-          ].map((item) => (
-            <div class="rounded-xl border transition-all duration-200 hover:border-edge-strong hover:shadow-md overflow-hidden bg-surface border-edge">
-              <div class="checkerboard border-b border-edge overflow-hidden" style="aspect-ratio: 1200/630;">
-                <img src={item.img} alt={item.title} width="600" height="400" class="w-full h-full object-contain block" loading="lazy" />
-              </div>
-              <div class="p-6">
-                <h3 class="font-heading font-semibold text-lg mb-2 text-heading">{item.title}</h3>
-                <p class="text-sm leading-relaxed text-body">{item.desc}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-
-    <!-- Getting Started Steps -->
-    <section id="getting-started" class="py-24 px-6 border-t border-edge">
-      <div class="max-w-3xl mx-auto">
-        <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Get Started in 3 Steps</h2>
-        </div>
-
-        <div class="space-y-12">
-          <!-- Step 1 -->
-          <div>
-            <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
-                <span class="font-heading font-bold text-base text-pink">1</span>
-              </div>
-              <h3 class="font-heading font-semibold text-2xl text-heading">Install</h3>
-            </div>
-            <p class="text-base mb-4 ml-14 text-body">One package. WebKit is downloaded automatically.</p>
-            <div class="ml-14">
-              <CodeBlock lang="bash" code="npm install grafex" />
-            </div>
-          </div>
-
-          <!-- Step 2 -->
-          <div>
-            <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
-                <span class="font-heading font-bold text-base text-pink">2</span>
-              </div>
-              <h3 class="font-heading font-semibold text-2xl text-heading">Write a composition</h3>
-            </div>
-            <p class="text-base mb-4 ml-14 text-body">Create a TSX file. Export a component and a config.</p>
-            <CodeBlock lang="tsx" label="card.tsx" code={step2Code} maxHeight="400px" class="ml-14" />
-          </div>
-
-          <!-- Step 3 -->
-          <div>
-            <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
-                <span class="font-heading font-bold text-base text-pink">3</span>
-              </div>
-              <h3 class="font-heading font-semibold text-2xl text-heading">Export</h3>
-            </div>
-            <p class="text-base mb-4 ml-14 text-body">Run one command. Get an image.</p>
-            <div class="ml-14">
-              <CodeBlock lang="bash" code="npx grafex export -f card.tsx -o card.png" />
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- CTA Band -->
-    <section class="py-20 px-6 bg-surface border-t border-edge">
-      <div class="max-w-2xl mx-auto text-center">
-        <h2 class="font-heading font-bold text-4xl mb-8 gradient-text">
-          Start Making Images.
-        </h2>
-
-        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mb-8 border bg-base border-edge">
-          <code class="font-mono text-sm text-lime">npm install grafex</code>
-          <CopyButton text="npm install grafex" client:load />
-        </div>
-
-        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <a
-            href="/docs/getting-started"
-            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
-          >
-            Get Started
-          </a>
-          <a
-            href="https://github.com/grafex-dev/grafex"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
-            </svg>
-            View on GitHub
-          </a>
-        </div>
-      </div>
-    </section>
-
-    <!-- Footer -->
-    <footer class="py-8 px-6 border-t border-edge bg-base">
-      <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
-        <div class="flex items-center gap-3">
-          <span class="text-sm font-semibold text-body">Grafex</span>
-          <span class="text-xs text-muted">MIT License</span>
-        </div>
-        <nav class="flex items-center gap-6">
-          <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
-          <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
-          <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
-        </nav>
-      </div>
-    </footer>
-  </main>
-
-  <script>
-    const menuBtn = document.getElementById('mobile-menu-btn');
-    const mobileMenu = document.getElementById('mobile-menu');
-
-    menuBtn?.addEventListener('click', () => {
-      const isOpen = !mobileMenu?.classList.contains('hidden');
-      mobileMenu?.classList.toggle('hidden');
-      menuBtn.setAttribute('aria-expanded', String(!isOpen));
-    });
-
-    mobileMenu?.querySelectorAll('a').forEach(link => {
-      link.addEventListener('click', () => {
-        mobileMenu.classList.add('hidden');
-        menuBtn?.setAttribute('aria-expanded', 'false');
-      });
-    });
-
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && !mobileMenu?.classList.contains('hidden')) {
-        mobileMenu?.classList.add('hidden');
-        menuBtn?.setAttribute('aria-expanded', 'false');
-      }
-    });
-
-    const nav = document.getElementById('site-nav');
-    function updateNav() {
-      if (window.scrollY > 50) {
-        nav?.classList.add('nav-scrolled');
-      } else {
-        nav?.classList.remove('nav-scrolled');
-      }
-    }
-    window.addEventListener('scroll', updateNav, { passive: true });
-    updateNav();
-  </script>
-</BaseLayout>
+  </section>
+</MarketingLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,8 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import CopyButton from '../components/CopyButton.tsx';
-import { Code } from 'astro:components';
-import { grafexTheme } from '../shiki-theme';
+import CodeBlock from '../components/CodeBlock.astro';
 
 const heroCode = `import type { CompositionConfig } from 'grafex';
 
@@ -65,54 +64,127 @@ const ogCardCode = `export const config = {
 
 export default function OgCard() {
   return (
-    <div style={{
-      width: '100%',
-      height: '100%',
-      background: 'linear-gradient(145deg, #0f172a, #1e293b)',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-      padding: '52px',
-      fontFamily: 'system-ui, sans-serif',
-      position: 'relative',
-    }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-        <div style={{
-          background: 'rgba(163,230,53,0.15)',
-          border: '1px solid rgba(163,230,53,0.3)',
-          borderRadius: '6px',
-          padding: '4px 12px',
-          color: '#A3E635',
-          fontSize: '12px',
-          fontWeight: '600',
-          textTransform: 'uppercase',
-        }}>
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        background: 'linear-gradient(145deg, #0f172a 0%, #1e293b 100%)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '52px',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Top accent glow */}
+      <div
+        style={{
+          position: 'absolute',
+          top: '-60px',
+          right: '-60px',
+          width: '300px',
+          height: '300px',
+          background: 'radial-gradient(circle, rgba(244,114,182,0.2) 0%, transparent 70%)',
+        }}
+      />
+
+      {/* Top: tag */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', zIndex: 1 }}>
+        <div
+          style={{
+            background: 'rgba(163,230,53,0.15)',
+            border: '1px solid rgba(163,230,53,0.3)',
+            borderRadius: '6px',
+            padding: '4px 12px',
+            color: '#A3E635',
+            fontSize: '12px',
+            fontWeight: '600',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
           Tutorial
         </div>
         <span style={{ color: '#475569', fontSize: '13px' }}>5 min read</span>
       </div>
 
-      <div>
-        <div style={{ color: '#F1F5F9', fontSize: '36px', fontWeight: '700' }}>
+      {/* Middle: title */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', zIndex: 1 }}>
+        <div
+          style={{
+            color: '#F1F5F9',
+            fontSize: '36px',
+            fontWeight: '700',
+            lineHeight: '1.2',
+            letterSpacing: '-0.5px',
+          }}
+        >
           Building Modern APIs
         </div>
-        <div style={{ color: '#94A3B8', fontSize: '16px', marginTop: '16px' }}>
+        <div style={{ color: '#94A3B8', fontSize: '16px', lineHeight: '1.5' }}>
           Best practices for REST and GraphQL in 2026
         </div>
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-        <div style={{
-          width: '36px', height: '36px', borderRadius: '50%',
-          background: 'linear-gradient(135deg, #F472B6, #38BDF8)',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          color: 'white', fontSize: '14px', fontWeight: '700',
-        }}>JS</div>
-        <div>
-          <div style={{ color: '#E2E8F0', fontSize: '14px' }}>Jane Smith</div>
-          <div style={{ color: '#64748B', fontSize: '12px' }}>March 15, 2026</div>
+      {/* Bottom: author + meta */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          zIndex: 1,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <div
+            style={{
+              width: '36px',
+              height: '36px',
+              borderRadius: '50%',
+              background: 'linear-gradient(135deg, #F472B6, #38BDF8)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'white',
+              fontSize: '14px',
+              fontWeight: '700',
+              flexShrink: 0,
+            }}
+          >
+            JS
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+            <span style={{ color: '#E2E8F0', fontSize: '14px', fontWeight: '600' }}>
+              Jane Smith
+            </span>
+            <span style={{ color: '#64748B', fontSize: '12px' }}>March 15, 2026</span>
+          </div>
+        </div>
+        <div
+          style={{
+            color: '#475569',
+            fontSize: '13px',
+            fontWeight: '600',
+            letterSpacing: '0.05em',
+          }}
+        >
+          dev.blog
         </div>
       </div>
+
+      {/* Bottom-left accent stripe */}
+      <div
+        style={{
+          position: 'absolute',
+          bottom: '0',
+          left: '0',
+          right: '0',
+          height: '3px',
+          background: 'linear-gradient(90deg, #F472B6, #38BDF8, #A3E635)',
+        }}
+      />
     </div>
   );
 }`;
@@ -125,8 +197,7 @@ export default function OgCard() {
   <!-- Skip to content -->
   <a
     href="#main-content"
-    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md"
-    style="color: var(--color-text-primary); background: var(--color-bg-surface); outline: 2px solid var(--color-border-focus);"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:text-heading focus:bg-surface focus:outline-2 focus:outline-ring"
   >
     Skip to content
   </a>
@@ -134,28 +205,27 @@ export default function OgCard() {
   <!-- Navigation -->
   <header id="site-nav" class="fixed top-0 left-0 right-0 z-40 h-16 transition-all duration-300 border-b border-transparent">
     <div class="max-w-7xl mx-auto px-6 h-full flex items-center justify-between">
-      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-[var(--color-text-primary)]">Grafex</a>
+      <a href="/" class="font-heading font-bold text-xl transition-opacity duration-150 ease-out hover:opacity-80 text-heading">Grafex</a>
 
       <!-- Desktop nav -->
       <nav class="hidden md:flex items-center gap-8">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
-        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Why Grafex</a>
-        <a href="#use-cases" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
+        <a href="#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
       </nav>
 
       <div class="hidden md:block">
         <a
           href="/docs/getting-started"
-          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110"
-          style="background: linear-gradient(135deg, #F472B6, var(--color-purple));"
+          class="px-5 py-2 rounded-lg text-sm font-semibold text-white transition-all hover:brightness-110 gradient-cta"
         >
           Get Started
         </a>
       </div>
 
       <!-- Mobile hamburger -->
-      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors" style="color: var(--color-text-secondary);" aria-label="Open menu" aria-expanded="false">
+      <button id="mobile-menu-btn" class="md:hidden p-2 rounded-md transition-colors text-body" aria-label="Open menu" aria-expanded="false">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
           <line x1="3" y1="6" x2="21" y2="6"/>
           <line x1="3" y1="12" x2="21" y2="12"/>
@@ -165,13 +235,13 @@ export default function OgCard() {
     </div>
 
     <!-- Mobile menu -->
-    <div id="mobile-menu" class="hidden md:hidden border-t" style="background: var(--color-bg-base); border-color: var(--color-border-default);">
+    <div id="mobile-menu" class="hidden md:hidden border-t bg-base border-edge">
       <nav class="px-6 py-4 flex flex-col gap-4">
-        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
-        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Why Grafex</a>
-        <a href="#use-cases" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
-        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center" style="background: linear-gradient(135deg, #F472B6, var(--color-purple));">
+        <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
+        <a href="#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
+        <a href="#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
+        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta hover:brightness-110 transition-all">
           Get Started
         </a>
       </nav>
@@ -185,23 +255,23 @@ export default function OgCard() {
 
       <div class="relative max-w-4xl mx-auto">
         <!-- Eyebrow badge -->
-        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider mb-8 border" style="background: rgba(163, 230, 53, 0.1); color: var(--color-accent-lime); border-color: rgba(163, 230, 53, 0.2);">
+        <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-wider mb-8 border text-lime bg-lime-muted border-lime/20">
           Open Source
         </div>
 
         <!-- Headline -->
-        <h1 class="font-heading font-bold text-5xl md:text-6xl lg:text-7xl leading-tight tracking-tight mb-6" style="background: linear-gradient(135deg, #F472B6, #38BDF8); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">
+        <h1 class="font-heading font-bold text-5xl md:text-6xl lg:text-7xl leading-tight tracking-tight mb-6 gradient-text">
           Images as Code.
         </h1>
 
         <!-- Subheadline -->
-        <p class="text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed" style="color: var(--color-text-secondary);">
+        <p class="text-lg md:text-xl max-w-2xl mx-auto mb-10 leading-relaxed text-body">
           Write JSX compositions with full CSS support. Export as images. No browser window, no server, no ceremony.
         </p>
 
         <!-- Install command -->
-        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mx-auto mb-8 border" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npm install grafex</code>
+        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mx-auto mb-8 border bg-surface border-edge">
+          <code class="font-mono text-sm text-lime">npm install grafex</code>
           <CopyButton text="npm install grafex" client:load />
         </div>
 
@@ -209,8 +279,7 @@ export default function OgCard() {
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
           <a
             href="/docs/getting-started"
-            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center"
-            style="background: linear-gradient(135deg, #F472B6, var(--color-purple)); box-shadow: 0 0 20px rgba(244, 114, 182, 0.2);"
+            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
           >
             Get Started
           </a>
@@ -218,7 +287,7 @@ export default function OgCard() {
             href="https://github.com/grafex-dev/grafex"
             target="_blank"
             rel="noopener noreferrer"
-            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-[var(--color-bg-surface-hover)] hover:border-[var(--color-primary)] text-[var(--color-text-primary)] border-[var(--color-border-strong)]"
+            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
@@ -228,21 +297,11 @@ export default function OgCard() {
         </div>
 
         <!-- Hero demo: Code + Output -->
-        <div class="max-w-4xl mx-auto rounded-2xl overflow-hidden border" style="border-color: var(--color-border-default); box-shadow: 0 8px 24px rgba(0,0,0,0.5);">
+        <div class="max-w-4xl mx-auto rounded-2xl overflow-hidden border border-edge shadow-lg">
           <div class="flex flex-col lg:flex-row">
             <!-- Left pane: Code -->
-            <div class="flex-1 border-b lg:border-b-0 lg:border-r" style="border-color: var(--color-border-strong);">
-              <!-- Code header -->
-              <div class="flex items-center justify-between px-4 py-2.5 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-                <div class="flex items-center gap-3">
-                  <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-                </div>
-                <CopyButton text={heroCode} client:load />
-              </div>
-              <!-- Code content -->
-              <div class="overflow-x-auto text-left [&_pre]:p-6 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 400px; overflow-y: auto;">
-                <Code code={heroCode} lang="tsx" theme={grafexTheme} />
-              </div>
+            <div class="flex-1 border-b lg:border-b-0 lg:border-r border-edge-strong">
+              <CodeBlock label="card.tsx" code={heroCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
             </div>
 
             <!-- Right pane: Output -->
@@ -250,7 +309,7 @@ export default function OgCard() {
               <div class="w-full rounded-xl overflow-hidden shadow-lg flex items-center justify-center" style="background: linear-gradient(135deg, #667eea, #764ba2); aspect-ratio: 1200/630; max-width: 360px;">
                 <span style="color: white; font-size: clamp(14px, 3.5vw, 24px); font-weight: bold; font-family: system-ui, sans-serif; text-align: center; padding: 1rem;">Hello, Grafex!</span>
               </div>
-              <span class="absolute bottom-3 right-4 text-xs font-mono" style="color: var(--color-text-muted);">output.png</span>
+              <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">output.png</span>
             </div>
           </div>
         </div>
@@ -258,108 +317,89 @@ export default function OgCard() {
     </section>
 
     <!-- Why Grafex -->
-    <section id="why-grafex" class="py-24 px-6" style="border-top: 1px solid var(--color-border-default);">
+    <section id="why-grafex" class="py-24 px-6 border-t border-edge">
       <div class="max-w-6xl mx-auto">
         <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4" style="color: var(--color-text-primary);">Why Grafex?</h2>
-          <p class="text-lg max-w-2xl mx-auto" style="color: var(--color-text-secondary);">Full CSS. Real browser engine. Zero configuration. The image composition tool you actually wanted.</p>
+          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Why Grafex?</h2>
+          <p class="text-lg max-w-2xl mx-auto text-body">Full CSS. Real browser engine. Zero configuration. The image composition tool you actually wanted.</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-[var(--color-border-strong)] hover:shadow-md" style="background: var(--color-bg-surface); border-color: var(--color-border-default); border-top: 2px solid var(--color-primary);">
-            <div class="mb-4" style="color: var(--color-primary);">
+          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-pink hover:border-t-pink">
+            <div class="mb-4 text-pink">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path d="M18.37 2.63 14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a1 1 0 0 0-3-3Z"/><path d="M9 8c-2 3-4 3.5-7 4l8 8c1-.5 3.5-2 4-7"/><path d="M14.5 17.5 4.5 15"/>
               </svg>
             </div>
-            <h3 class="font-heading font-semibold text-lg mb-2" style="color: var(--color-text-primary);">Full CSS Support</h3>
-            <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">Flexbox, Grid, gradients, shadows, custom fonts — real CSS rendered by a real browser engine. Not a subset. Not reimplemented. The real thing.</p>
+            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Full CSS Support</h3>
+            <p class="text-sm leading-relaxed text-body">Flexbox, Grid, gradients, shadows, custom fonts — real CSS rendered by a real browser engine. Not a subset. Not reimplemented. The real thing.</p>
           </div>
 
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-[var(--color-border-strong)] hover:shadow-md" style="background: var(--color-bg-surface); border-color: var(--color-border-default); border-top: 2px solid var(--color-accent-lime);">
-            <div class="mb-4" style="color: var(--color-accent-lime);">
+          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-lime hover:border-t-lime">
+            <div class="mb-4 text-lime">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
               </svg>
             </div>
-            <h3 class="font-heading font-semibold text-lg mb-2" style="color: var(--color-text-primary);">Fast Renders</h3>
-            <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">5-50ms warm renders. Sub-second cold starts. WebKit launches once and stays ready.</p>
+            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">Fast Renders</h3>
+            <p class="text-sm leading-relaxed text-body">5-50ms warm renders. Sub-second cold starts. WebKit launches once and stays ready.</p>
           </div>
 
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-[var(--color-border-strong)] hover:shadow-md" style="background: var(--color-bg-surface); border-color: var(--color-border-default); border-top: 2px solid var(--color-secondary);">
-            <div class="mb-4" style="color: var(--color-secondary);">
+          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-sky hover:border-t-sky">
+            <div class="mb-4 text-sky">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/>
               </svg>
             </div>
-            <h3 class="font-heading font-semibold text-lg mb-2" style="color: var(--color-text-primary);">AI-Friendly</h3>
-            <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">Compositions are plain JSX functions. Any LLM can write them, modify them, and reason about them.</p>
+            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">AI-Friendly</h3>
+            <p class="text-sm leading-relaxed text-body">Compositions are plain JSX functions. Any LLM can write them, modify them, and reason about them.</p>
           </div>
 
-          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-[var(--color-border-strong)] hover:shadow-md" style="background: var(--color-bg-surface); border-color: var(--color-border-default); border-top: 2px solid var(--color-accent-amber);">
-            <div class="mb-4" style="color: var(--color-accent-amber);">
+          <div class="rounded-xl p-6 border transition-all duration-200 hover:border-edge-strong hover:shadow-md bg-surface border-edge border-t-2 border-t-amber hover:border-t-amber">
+            <div class="mb-4 text-amber">
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                 <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>
               </svg>
             </div>
-            <h3 class="font-heading font-semibold text-lg mb-2" style="color: var(--color-text-primary);">No Browser Window</h3>
-            <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">WebKit runs headlessly behind the scenes. No Puppeteer scripts. No browser lifecycle management. Just import, render, done.</p>
+            <h3 class="font-heading font-semibold text-lg mb-2 text-heading">No Browser Window</h3>
+            <p class="text-sm leading-relaxed text-body">WebKit runs headlessly behind the scenes. No Puppeteer scripts. No browser lifecycle management. Just import, render, done.</p>
           </div>
         </div>
       </div>
     </section>
 
     <!-- Code Example -->
-    <section id="code-example" class="py-24 px-6" style="border-top: 1px solid var(--color-border-default);">
+    <section id="code-example" class="py-24 px-6 border-t border-edge">
       <div class="max-w-6xl mx-auto">
         <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4" style="color: var(--color-text-primary);">Compositions Are Just Functions</h2>
-          <p class="text-lg max-w-2xl mx-auto" style="color: var(--color-text-secondary);">A composition is a TSX file that exports a function and a config. Accept props, use components, style with CSS — all the patterns you already know.</p>
+          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Compositions Are Just Functions</h2>
+          <p class="text-lg max-w-2xl mx-auto text-body">A composition is a TSX file that exports a function and a config. Accept props, use components, style with CSS — all the patterns you already know.</p>
         </div>
 
         <!-- Code + Output: unified container -->
-        <div class="rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-          <!-- Code header -->
-          <div class="flex items-center justify-between px-4 py-2.5 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs font-mono" style="color: var(--color-text-muted);">og-card.tsx</span>
-            <CopyButton
-              text={ogCardCode}
-              client:load
-            />
-          </div>
-          <!-- Code content -->
-          <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 400px; overflow-y: auto;">
-            <Code code={ogCardCode} lang="tsx" theme={grafexTheme} />
-          </div>
+        <div class="rounded-xl overflow-hidden border border-edge">
+          <CodeBlock label="og-card.tsx" code={ogCardCode} lang="tsx" maxHeight="400px" class="rounded-none border-0 mb-0" />
           <!-- Output image: directly below code, no gap, shares border -->
-          <div class="checkerboard border-t relative flex items-center justify-center p-6" style="border-color: var(--color-border-default);">
-            <img src="/examples/og-card.png" alt="Generated OG card showing 'Building Modern APIs'" class="rounded-lg shadow-2xl" style="max-width: 600px; width: 100%;" />
-            <span class="absolute bottom-3 right-4 text-xs font-mono" style="color: var(--color-text-muted);">og-card.png</span>
+          <div class="checkerboard border-t border-edge relative flex items-center justify-center p-6">
+            <img src="/examples/og-card.png" alt="Generated OG card showing 'Building Modern APIs'" class="rounded-lg shadow-2xl w-full max-w-[600px]" />
+            <span class="absolute bottom-3 right-4 text-xs font-mono text-muted">og-card.png</span>
           </div>
         </div>
 
         <!-- CLI command -->
-        <div class="mt-4 rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-          <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-            <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-            <CopyButton text="npx grafex export -f og-card.tsx -o og-card.png" client:load />
-          </div>
-          <div class="px-4 py-3" style="background: var(--color-bg-code);">
-            <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx grafex export -f og-card.tsx -o og-card.png</code>
-          </div>
-        </div>
+        <CodeBlock lang="bash" code="npx grafex export -f og-card.tsx -o og-card.png" class="mt-4" />
 
         <p class="text-center mt-6">
-          <a href="/docs/examples" class="text-sm font-medium transition-colors duration-150 no-underline hover:no-underline text-[var(--color-primary)] hover:text-[#F9A8D4]">See more examples →</a>
+          <a href="/docs/examples" class="text-sm font-medium transition-colors duration-150 no-underline hover:no-underline text-pink hover:text-pink-hover">See more examples →</a>
         </p>
       </div>
     </section>
 
     <!-- Use Cases -->
-    <section id="use-cases" class="py-24 px-6" style="border-top: 1px solid var(--color-border-default);">
+    <section id="use-cases" class="py-24 px-6 border-t border-edge">
       <div class="max-w-6xl mx-auto">
         <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4" style="color: var(--color-text-primary);">What You Can Build</h2>
+          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">What You Can Build</h2>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -371,13 +411,13 @@ export default function OgCard() {
             { title: 'Video Thumbnails', desc: 'YouTube and podcast covers generated from a single template.', img: '/examples/thumbnail.png' },
             { title: 'Diagrams & Charts', desc: 'Architecture diagrams and data visualizations, version-controlled as code.', img: '/examples/diagram.png' },
           ].map((item) => (
-            <div class="rounded-xl border transition-all duration-200 hover:border-[var(--color-border-strong)] hover:shadow-md overflow-hidden" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-              <div class="checkerboard border-b overflow-hidden" style="aspect-ratio: 1200/630; border-color: var(--color-border-default);">
-                <img src={item.img} alt={item.title} width="600" height="400" style="width: 100%; height: 100%; object-fit: contain; display: block;" loading="lazy" />
+            <div class="rounded-xl border transition-all duration-200 hover:border-edge-strong hover:shadow-md overflow-hidden bg-surface border-edge">
+              <div class="checkerboard border-b border-edge overflow-hidden" style="aspect-ratio: 1200/630;">
+                <img src={item.img} alt={item.title} width="600" height="400" class="w-full h-full object-contain block" loading="lazy" />
               </div>
               <div class="p-6">
-                <h3 class="font-heading font-semibold text-lg mb-2" style="color: var(--color-text-primary);">{item.title}</h3>
-                <p class="text-sm leading-relaxed" style="color: var(--color-text-secondary);">{item.desc}</p>
+                <h3 class="font-heading font-semibold text-lg mb-2 text-heading">{item.title}</h3>
+                <p class="text-sm leading-relaxed text-body">{item.desc}</p>
               </div>
             </div>
           ))}
@@ -386,70 +426,50 @@ export default function OgCard() {
     </section>
 
     <!-- Getting Started Steps -->
-    <section id="getting-started" class="py-24 px-6" style="border-top: 1px solid var(--color-border-default);">
+    <section id="getting-started" class="py-24 px-6 border-t border-edge">
       <div class="max-w-3xl mx-auto">
         <div class="text-center mb-16">
-          <h2 class="font-heading font-bold text-4xl mb-4" style="color: var(--color-text-primary);">Get Started in 3 Steps</h2>
+          <h2 class="font-heading font-bold text-4xl mb-4 text-heading">Get Started in 3 Steps</h2>
         </div>
 
         <div class="space-y-12">
           <!-- Step 1 -->
           <div>
             <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0" style="background: var(--color-bg-surface); border-color: var(--color-border-strong);">
-                <span class="font-heading font-bold text-base" style="color: var(--color-primary);">1</span>
+              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+                <span class="font-heading font-bold text-base text-pink">1</span>
               </div>
-              <h3 class="font-heading font-semibold text-2xl" style="color: var(--color-text-primary);">Install</h3>
+              <h3 class="font-heading font-semibold text-2xl text-heading">Install</h3>
             </div>
-            <p class="text-base mb-4 ml-14" style="color: var(--color-text-secondary);">One package. WebKit is downloaded automatically.</p>
-            <div class="ml-14 rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-              <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-                <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-                <CopyButton text="npm install grafex" client:load />
-              </div>
-              <div class="px-4 py-3" style="background: var(--color-bg-code);">
-                <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npm install grafex</code>
-              </div>
+            <p class="text-base mb-4 ml-14 text-body">One package. WebKit is downloaded automatically.</p>
+            <div class="ml-14">
+              <CodeBlock lang="bash" code="npm install grafex" />
             </div>
           </div>
 
           <!-- Step 2 -->
           <div>
             <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0" style="background: var(--color-bg-surface); border-color: var(--color-border-strong);">
-                <span class="font-heading font-bold text-base" style="color: var(--color-primary);">2</span>
+              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+                <span class="font-heading font-bold text-base text-pink">2</span>
               </div>
-              <h3 class="font-heading font-semibold text-2xl" style="color: var(--color-text-primary);">Write a composition</h3>
+              <h3 class="font-heading font-semibold text-2xl text-heading">Write a composition</h3>
             </div>
-            <p class="text-base mb-4 ml-14" style="color: var(--color-text-secondary);">Create a TSX file. Export a component and a config.</p>
-            <div class="ml-14 rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-              <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-                <span class="text-xs font-mono" style="color: var(--color-text-muted);">card.tsx</span>
-                <CopyButton text={step2Code} client:load />
-              </div>
-              <div class="overflow-x-auto [&_pre]:p-4 [&_pre]:!bg-[var(--color-bg-code)] [&_pre]:m-0 [&_code]:font-mono [&_code]:text-sm [&_code]:leading-relaxed" style="max-height: 400px; overflow-y: auto;">
-                <Code code={step2Code} lang="tsx" theme={grafexTheme} />
-              </div>
-            </div>
+            <p class="text-base mb-4 ml-14 text-body">Create a TSX file. Export a component and a config.</p>
+            <CodeBlock lang="tsx" label="card.tsx" code={step2Code} maxHeight="400px" class="ml-14" />
           </div>
 
           <!-- Step 3 -->
           <div>
             <div class="flex items-center gap-4 mb-4">
-              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0" style="background: var(--color-bg-surface); border-color: var(--color-border-strong);">
-                <span class="font-heading font-bold text-base" style="color: var(--color-primary);">3</span>
+              <div class="w-10 h-10 rounded-full flex items-center justify-center border flex-shrink-0 bg-surface border-edge-strong">
+                <span class="font-heading font-bold text-base text-pink">3</span>
               </div>
-              <h3 class="font-heading font-semibold text-2xl" style="color: var(--color-text-primary);">Export</h3>
+              <h3 class="font-heading font-semibold text-2xl text-heading">Export</h3>
             </div>
-            <p class="text-base mb-4 ml-14" style="color: var(--color-text-secondary);">Run one command. Get an image.</p>
-            <div class="ml-14 rounded-xl overflow-hidden border" style="border-color: var(--color-border-default);">
-              <div class="flex items-center justify-between px-4 py-2 border-b" style="background: var(--color-bg-surface); border-color: var(--color-border-default);">
-                <span class="text-xs uppercase tracking-wider font-medium" style="color: var(--color-text-muted);">bash</span>
-                <CopyButton text="npx grafex export -f card.tsx -o card.png" client:load />
-              </div>
-              <div class="px-4 py-3" style="background: var(--color-bg-code);">
-                <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npx grafex export -f card.tsx -o card.png</code>
-              </div>
+            <p class="text-base mb-4 ml-14 text-body">Run one command. Get an image.</p>
+            <div class="ml-14">
+              <CodeBlock lang="bash" code="npx grafex export -f card.tsx -o card.png" />
             </div>
           </div>
         </div>
@@ -457,22 +477,21 @@ export default function OgCard() {
     </section>
 
     <!-- CTA Band -->
-    <section class="py-20 px-6" style="background: var(--color-bg-surface); border-top: 1px solid var(--color-border-default);">
+    <section class="py-20 px-6 bg-surface border-t border-edge">
       <div class="max-w-2xl mx-auto text-center">
-        <h2 class="font-heading font-bold text-4xl mb-8" style="background: linear-gradient(135deg, #F472B6, #38BDF8); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">
+        <h2 class="font-heading font-bold text-4xl mb-8 gradient-text">
           Start Making Images.
         </h2>
 
-        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mb-8 border" style="background: var(--color-bg-base); border-color: var(--color-border-default);">
-          <code class="font-mono text-sm" style="color: var(--color-accent-lime);">npm install grafex</code>
+        <div class="inline-flex items-center gap-3 px-5 py-3 rounded-full mb-8 border bg-base border-edge">
+          <code class="font-mono text-sm text-lime">npm install grafex</code>
           <CopyButton text="npm install grafex" client:load />
         </div>
 
         <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
           <a
             href="/docs/getting-started"
-            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center"
-            style="background: linear-gradient(135deg, #F472B6, var(--color-purple)); box-shadow: 0 0 20px rgba(244, 114, 182, 0.2);"
+            class="px-8 py-3.5 rounded-lg text-base font-semibold text-white transition-all hover:brightness-110 min-h-[48px] flex items-center gradient-cta shadow-glow-pink"
           >
             Get Started
           </a>
@@ -480,7 +499,7 @@ export default function OgCard() {
             href="https://github.com/grafex-dev/grafex"
             target="_blank"
             rel="noopener noreferrer"
-            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-[var(--color-bg-surface-hover)] hover:border-[var(--color-primary)] text-[var(--color-text-primary)] border-[var(--color-border-strong)]"
+            class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
@@ -492,16 +511,16 @@ export default function OgCard() {
     </section>
 
     <!-- Footer -->
-    <footer class="py-8 px-6 border-t" style="border-color: var(--color-border-default); background: var(--color-bg-base);">
+    <footer class="py-8 px-6 border-t border-edge bg-base">
       <div class="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
         <div class="flex items-center gap-3">
-          <span class="text-sm font-semibold" style="color: var(--color-text-secondary);">Grafex</span>
-          <span class="text-xs" style="color: var(--color-text-muted);">MIT License</span>
+          <span class="text-sm font-semibold text-body">Grafex</span>
+          <span class="text-xs text-muted">MIT License</span>
         </div>
         <nav class="flex items-center gap-6">
-          <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">GitHub</a>
-          <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">npm</a>
-          <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] no-underline">Docs</a>
+          <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+          <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
+          <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
         </nav>
       </div>
     </footer>
@@ -534,17 +553,9 @@ export default function OgCard() {
     const nav = document.getElementById('site-nav');
     function updateNav() {
       if (window.scrollY > 50) {
-        if (nav) {
-          nav.style.background = 'rgba(11, 17, 32, 0.92)';
-          nav.style.backdropFilter = 'blur(12px)';
-          nav.style.borderColor = 'var(--color-border-default)';
-        }
+        nav?.classList.add('nav-scrolled');
       } else {
-        if (nav) {
-          nav.style.background = 'transparent';
-          nav.style.backdropFilter = 'none';
-          nav.style.borderColor = 'transparent';
-        }
+        nav?.classList.remove('nav-scrolled');
       }
     }
     window.addEventListener('scroll', updateNav, { passive: true });

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -5,40 +5,85 @@
 @source "../components/**/*.{astro,tsx}";
 
 @theme {
-  --color-bg-base: #0b1120;
-  --color-bg-surface: #1e293b;
-  --color-bg-surface-hover: #263548;
-  --color-bg-code: #0f1729;
-  --color-bg-elevated: #283548;
+  /* Reset built-in palettes */
+  --color-*: initial;
+  --font-*: initial;
+  --shadow-*: initial;
 
-  --color-text-primary: #f1f5f9;
-  --color-text-secondary: #94a3b8;
-  --color-text-muted: #64748b;
-  --color-text-on-accent: #0b1120;
+  /* ── Surfaces ── */
+  --color-base: #0b1120;
+  --color-surface: #1e293b;
+  --color-surface-hover: #263548;
+  --color-codeblock: #0f1729;
+  --color-elevated: #283548;
 
-  --color-border-default: #1e293b;
-  --color-border-strong: #334155;
-  --color-border-focus: #f472b6;
+  /* ── Text ── */
+  --color-heading: #f1f5f9;
+  --color-body: #94a3b8;
+  --color-muted: #64748b;
+  --color-on-accent: #0b1120;
 
-  --color-primary: #f472b6;
-  --color-primary-hover: #f9a8d4;
+  /* ── Edges (borders) ── */
+  --color-edge: #1e293b;
+  --color-edge-strong: #334155;
+  --color-ring: #f472b6;
 
-  --color-secondary: #38bdf8;
-  --color-secondary-hover: #7dd3fc;
+  /* ── Pink (primary brand) ── */
+  --color-pink: #f472b6;
+  --color-pink-hover: #f9a8d4;
+  --color-pink-muted: rgba(244, 114, 182, 0.15);
 
-  --color-accent-lime: #a3e635;
-  --color-accent-lime-hover: #bef264;
+  /* ── Sky (secondary / informational) ── */
+  --color-sky: #38bdf8;
+  --color-sky-hover: #7dd3fc;
+  --color-sky-muted: rgba(56, 189, 248, 0.15);
 
-  --color-accent-amber: #fb923c;
-  --color-accent-amber-hover: #fdba74;
+  /* ── Lime (success / new) ── */
+  --color-lime: #a3e635;
+  --color-lime-hover: #bef264;
+  --color-lime-muted: rgba(163, 230, 53, 0.15);
 
+  /* ── Amber (warnings / tips) ── */
+  --color-amber: #fb923c;
+  --color-amber-hover: #fdba74;
+  --color-amber-muted: rgba(251, 146, 60, 0.15);
+
+  /* ── Purple (gradient accent) ── */
   --color-purple: #a855f7;
 
+  /* ── Semantic ── */
   --color-error: #f87171;
+  --color-error-muted: rgba(248, 113, 113, 0.15);
 
+  /* ── White / Black (needed since we reset) ── */
+  --color-white: #ffffff;
+  --color-black: #000000;
+  --color-transparent: transparent;
+  --color-current: currentColor;
+
+  /* ── Fonts ── */
   --font-heading: 'Space Grotesk', system-ui, sans-serif;
   --font-body: 'DM Sans', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', monospace;
+
+  /* ── Shadows ── */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --shadow-glow-pink: 0 0 20px rgba(244, 114, 182, 0.2);
+  --shadow-glow-sky: 0 0 20px rgba(56, 189, 248, 0.15);
+}
+
+.gradient-hero {
+  background: linear-gradient(135deg, var(--color-pink), var(--color-sky));
+}
+.gradient-cta {
+  background: linear-gradient(135deg, var(--color-pink), var(--color-purple));
+}
+.gradient-text {
+  background: linear-gradient(135deg, var(--color-pink), var(--color-sky));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .checkerboard {
@@ -56,6 +101,12 @@
   background-color: #12121f;
 }
 
+.nav-scrolled {
+  background: color-mix(in srgb, var(--color-base) 92%, transparent);
+  backdrop-filter: blur(12px);
+  border-color: var(--color-edge);
+}
+
 @layer base {
   h2,
   h3 {
@@ -63,8 +114,8 @@
   }
 
   body {
-    background-color: var(--color-bg-base);
-    color: var(--color-text-primary);
+    background-color: var(--color-base);
+    color: var(--color-heading);
     font-family: var(--font-body);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -72,7 +123,7 @@
 
   * {
     scrollbar-width: thin;
-    scrollbar-color: var(--color-border-strong) transparent;
+    scrollbar-color: var(--color-edge-strong) transparent;
   }
 
   *::-webkit-scrollbar {
@@ -81,16 +132,16 @@
   }
 
   *::-webkit-scrollbar-track {
-    background: var(--color-bg-surface);
+    background: var(--color-surface);
   }
 
   *::-webkit-scrollbar-thumb {
-    background: var(--color-border-strong);
+    background: var(--color-edge-strong);
     border-radius: 4px;
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    background: var(--color-text-muted);
+    background: var(--color-muted);
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Large-scale refactor of the Grafex website to properly use Tailwind's `@theme` tokens, extract reusable components, and eliminate inline style / arbitrary value leakage.

### Tailwind theme
- Reset built-in color/font/shadow palettes (`--color-*: initial`) so only design system tokens exist
- Rename tokens to avoid double prefixes (`bg-base`, `text-heading`, `border-edge`, `text-pink`)
- Add muted/alpha variants, shadow tokens, and font tokens

### Component extraction
- `InlineCode` — pink pill for inline code references (replaced 46 occurrences)
- `Callout` — tip/warning/info boxes with colored left border (replaced 10 occurrences)
- `CodeBlock` extended with `label` and `collapsible` props (replaced 50+ hand-rolled code blocks)
- `MarketingLayout` — shared nav, mobile menu, footer, scroll handler for index + 404 (fixes 404 bug where nav was missing "Why Grafex" and "Examples" links)

### Infrastructure
- Add `tailwind-merge` via `cn()` helper (`src/lib/cn.ts`) for clean class overrides
- Add `typecheck` script (`astro check`)

### Bug fixes
- Fix feature cards losing colored top border on hover (was wiped by `hover:border-edge-strong`)
- Fix mobile CTA missing `hover:brightness-110` effect
- Fix h2 headings rendering at 14px due to `InlineCode`'s hardcoded `text-sm` (cli.astro, api.astro, browser-setup.astro)
- Fix race condition where `<InlineCode>` was wrongly used inside table cells, heading elements, and standalone terminal containers

## Test plan

- [x] `cd website && npx astro build` — 10 pages built
- [x] `cd website && npm run typecheck` — 0 errors, 0 warnings
- [x] Root Vitest library suite unaffected — 327 tests still pass
- [x] Visual review of all pages — no regressions