### PR TITLE
chore: update GitHub URLs to andresilva-cc after org transfer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ test: add integration test for --props flag
 
 ## What We're Looking For
 
-Check the [GitHub Issues](https://github.com/grafex-dev/grafex/issues) for open tasks. Issues labeled `good first issue` are a great starting point.
+Check the [GitHub Issues](https://github.com/andresilva-cc/grafex/issues) for open tasks. Issues labeled `good first issue` are a great starting point.
 
 For larger changes (new output formats, API redesigns, architectural shifts), **open an issue first** to discuss the approach. This saves everyone time and avoids duplicate work.
 
@@ -159,4 +159,4 @@ Be respectful. We're all here to build something useful. Harassment, discriminat
 
 ## Questions?
 
-Open a [GitHub Discussion](https://github.com/grafex-dev/grafex/discussions) or comment on a relevant issue. We're happy to help.
+Open a [GitHub Discussion](https://github.com/andresilva-cc/grafex/discussions) or comment on a relevant issue. We're happy to help.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/grafex-dev/grafex.git"
+    "url": "git+https://github.com/andresilva-cc/grafex.git"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -18,5 +18,5 @@ Key features: full CSS support (flexbox, grid, gradients, shadows, transforms), 
 
 ## Optional
 
-- [GitHub Repository](https://github.com/grafex-dev/grafex): Source code, issues, contributing
+- [GitHub Repository](https://github.com/andresilva-cc/grafex): Source code, issues, contributing
 - [npm Package](https://www.npmjs.com/package/grafex): Package registry page

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -50,7 +50,7 @@ const navItems = [
         <span class="hidden md:block text-sm text-body">Docs</span>
       </div>
       <a
-        href="https://github.com/grafex-dev/grafex"
+        href="https://github.com/andresilva-cc/grafex"
         target="_blank"
         rel="noopener noreferrer"
         class="flex items-center gap-2 text-sm text-body hover:text-heading transition-colors"

--- a/website/src/layouts/MarketingLayout.astro
+++ b/website/src/layouts/MarketingLayout.astro
@@ -33,7 +33,7 @@ const {
         <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
         <a href="/#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
         <a href="/#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="https://github.com/andresilva-cc/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
       </nav>
 
       <div class="hidden md:block">
@@ -61,7 +61,7 @@ const {
         <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
         <a href="/#why-grafex" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Why Grafex</a>
         <a href="/#use-cases" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Examples</a>
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="https://github.com/andresilva-cc/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
         <a href="/docs/getting-started" class="mt-2 px-5 py-2.5 rounded-lg text-sm font-semibold text-white text-center gradient-cta hover:brightness-110 transition-all">
           Get Started
         </a>
@@ -81,7 +81,7 @@ const {
         <span class="text-xs text-muted">MIT License</span>
       </div>
       <nav class="flex items-center gap-6">
-        <a href="https://github.com/grafex-dev/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
+        <a href="https://github.com/andresilva-cc/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">GitHub</a>
         <a href="https://www.npmjs.com/package/grafex" target="_blank" rel="noopener noreferrer" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">npm</a>
         <a href="/docs/getting-started" class="text-sm transition-colors duration-150 text-body hover:text-heading no-underline">Docs</a>
       </nav>

--- a/website/src/pages/docs/tailwind.astro
+++ b/website/src/pages/docs/tailwind.astro
@@ -153,7 +153,7 @@ const buildCmd = `npx @tailwindcss/cli -i ./input.css -o ./styles.css && npx gra
     <section class="mb-12">
       <h2 class="font-heading font-bold text-2xl mb-4 text-heading">Working example</h2>
       <p class="text-base leading-relaxed mb-4 text-body">
-        The <a href="https://github.com/grafex-dev/grafex/tree/main/examples/tailwind" class="text-pink">examples/tailwind/</a> directory in the repository contains a complete runnable example with all the files described on this page.
+        The <a href="https://github.com/andresilva-cc/grafex/tree/main/examples/tailwind" class="text-pink">examples/tailwind/</a> directory in the repository contains a complete runnable example with all the files described on this page.
       </p>
 
       <div class="rounded-xl p-5 border bg-surface border-edge">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -229,7 +229,7 @@ export default function OgCard() {
           Get Started
         </a>
         <a
-          href="https://github.com/grafex-dev/grafex"
+          href="https://github.com/andresilva-cc/grafex"
           target="_blank"
           rel="noopener noreferrer"
           class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"
@@ -441,7 +441,7 @@ export default function OgCard() {
           Get Started
         </a>
         <a
-          href="https://github.com/grafex-dev/grafex"
+          href="https://github.com/andresilva-cc/grafex"
           target="_blank"
           rel="noopener noreferrer"
           class="px-8 py-3.5 rounded-lg text-base font-medium transition-all min-h-[48px] flex items-center gap-2 border hover:bg-surface-hover hover:border-pink text-heading border-edge-strong"


### PR DESCRIPTION
Updates all hardcoded `github.com/grafex-dev/grafex` URLs to `github.com/andresilva-cc/grafex` following the repo transfer from the `grafex-dev` org to the personal account.

- `package.json` repository URL
- `CONTRIBUTING.md` issues + discussions links
- website GitHub links (MarketingLayout, DocsLayout, index, tailwind docs, llms.txt)

Domain `grafex.dev` references intentionally left unchanged (the domain doesn't move). Pure string swaps, no logic changes.